### PR TITLE
[CHORE] Make the temperatures Optional

### DIFF
--- a/src/main/scala/calespiga/model/State.scala
+++ b/src/main/scala/calespiga/model/State.scala
@@ -10,13 +10,12 @@ case class State(
 
 object State {
 
-  val sentinelTemp = -100.0
   case class Temperatures(
-      externalTemperature: Double = sentinelTemp,
-      batteriesTemperature: Double = sentinelTemp,
-      batteriesClosetTemperature: Double = sentinelTemp,
-      electronicsTemperature: Double = sentinelTemp,
-      goalTemperature: Double = sentinelTemp
+      externalTemperature: Option[Double] = None,
+      batteriesTemperature: Option[Double] = None,
+      batteriesClosetTemperature: Option[Double] = None,
+      electronicsTemperature: Option[Double] = None,
+      goalTemperature: Option[Double] = None
   )
   case class Fans(
       fanManagementAutomatic: Switch.Status = Switch.Off,

--- a/src/test/scala/calespiga/model/Fixture.scala
+++ b/src/test/scala/calespiga/model/Fixture.scala
@@ -6,10 +6,10 @@ object Fixture {
 
   val state: State = State(
     State.Temperatures(
-      externalTemperature = 20.0,
-      batteriesTemperature = 30.0,
-      electronicsTemperature = 40.0,
-      goalTemperature = 20.0
+      externalTemperature = Some(20.0),
+      batteriesTemperature = Some(30.0),
+      electronicsTemperature = Some(40.0),
+      goalTemperature = Some(20.0)
     ),
     State.Fans(
       fanBatteries = RemoteSwitch(),

--- a/src/test/scala/calespiga/persistence/StatePersistenceSuite.scala
+++ b/src/test/scala/calespiga/persistence/StatePersistenceSuite.scala
@@ -117,7 +117,7 @@ class StatePersistenceSuite extends CatsEffectSuite {
     Ref[IO].of[Option[(String, String)]](None).flatMap { ref =>
       val anotherState = someState
         .modify(_.temperatures.batteriesClosetTemperature)
-        .setTo(someState.temperatures.batteriesClosetTemperature + 1)
+        .setTo(someState.temperatures.batteriesClosetTemperature.map(_ + 1))
       val sut = StatePersistence(
         config,
         errorManager = ErrorManagerStub(),


### PR DESCRIPTION
Instead of a sentile value with an arbitrary value of -100, this PR sets up the temperatures with an optional, so when they are not set, the value is None, and once some value is received, they have the Some with the value.