### PR TITLE
[Feature] Generic offline detector

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -52,4 +52,9 @@ processor {
         battery-fan-id = "ventilador-bateries"
         electronics-fan-id = "ventilador-electronica"
     }
+    
+    offline-detector {
+        timeout-duration = 5 minutes
+        temperatures-status-item = "TemperaturesMicroControladorEstat"
+    }
 }

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -56,5 +56,7 @@ processor {
     offline-detector {
         timeout-duration = 5 minutes
         temperatures-status-item = "TemperaturesMicroControladorEstat"
+        online-text = "En línia"
+        offline-text = "Fora de línia"
     }
 }

--- a/src/main/scala/calespiga/config/ApplicationConfig.scala
+++ b/src/main/scala/calespiga/config/ApplicationConfig.scala
@@ -32,7 +32,8 @@ final case class StatePersistenceConfig(
 )
 
 final case class ProcessorConfig(
-    temperatureRelated: TemperatureRelatedConfig
+    temperatureRelated: TemperatureRelatedConfig,
+    offlineDetector: OfflineDetectorConfig
 ) derives ConfigReader
 
 final case class TemperatureRelatedConfig(
@@ -55,4 +56,9 @@ final case class TemperatureRelatedConfig(
     // Internal IDs for action tracking
     batteryFanId: String,
     electronicsFanId: String
+) derives ConfigReader
+
+final case class OfflineDetectorConfig(
+    timeoutDuration: FiniteDuration,
+    temperaturesStatusItem: String
 ) derives ConfigReader

--- a/src/main/scala/calespiga/config/ApplicationConfig.scala
+++ b/src/main/scala/calespiga/config/ApplicationConfig.scala
@@ -60,5 +60,7 @@ final case class TemperatureRelatedConfig(
 
 final case class OfflineDetectorConfig(
     timeoutDuration: FiniteDuration,
-    temperaturesStatusItem: String
+    temperaturesStatusItem: String,
+    onlineText: String,
+    offlineText: String
 ) derives ConfigReader

--- a/src/main/scala/calespiga/processor/OfflineDetectorProcessor.scala
+++ b/src/main/scala/calespiga/processor/OfflineDetectorProcessor.scala
@@ -1,28 +1,63 @@
 package calespiga.processor
 
 import calespiga.model.{Action, Event, State}
+import calespiga.config.OfflineDetectorConfig
 import java.time.Instant
 
 object OfflineDetectorProcessor {
 
-  private final case class Impl(
-      // Configuration will be added later
-  ) extends StateProcessor.SingleProcessor {
+  // Microcontroller status constants
+  val ONLINE = "En linia"
+  val OFFLINE = "Fora de línia"
+
+  private val TEMPERATURES_TIMEOUT_ID = "temperatures-offline-timeout"
+
+  def apply(config: OfflineDetectorConfig): StateProcessor.SingleProcessor = Impl(config)
+
+  private final case class Impl(config: OfflineDetectorConfig) extends StateProcessor.SingleProcessor {
 
     def process(
         state: State,
         eventData: Event.EventData,
         timestamp: Instant
     ): (State, Set[Action]) = {
-      // TODO: Implement offline detection logic
       eventData match {
+        // Handle startup event - schedule initial offline timeout
+        case Event.System.StartupEvent =>
+          val offlineAction = Action.SetOpenHabItemValue(config.temperaturesStatusItem, OFFLINE)
+          val delayedOfflineAction = Action.Delayed(
+            TEMPERATURES_TIMEOUT_ID,
+            offlineAction,
+            config.timeoutDuration
+          )
+          (state, Set(delayedOfflineAction))
+
+        // Handle events from Temperatures microcontroller
+        case _: Event.Temperature.BatteryTemperatureMeasured |
+             _: Event.Temperature.BatteryClosetTemperatureMeasured |
+             _: Event.Temperature.ElectronicsTemperatureMeasured |
+             _: Event.Temperature.ExternalTemperatureMeasured |
+             _: Event.Temperature.Fans.BatteryFanSwitchReported |
+             _: Event.Temperature.Fans.ElectronicsFanSwitchReported =>
+          
+          // Set status to online immediately
+          val setOnlineAction = Action.SetOpenHabItemValue(config.temperaturesStatusItem, ONLINE)
+          
+          // Schedule new offline timeout (automatically cancels previous one with same ID)
+          val offlineAction = Action.SetOpenHabItemValue(config.temperaturesStatusItem, OFFLINE)
+          val newDelayedOfflineAction = Action.Delayed(
+            TEMPERATURES_TIMEOUT_ID,
+            offlineAction,
+            config.timeoutDuration
+          )
+          
+          (state, Set(setOnlineAction, newDelayedOfflineAction))
+
+        // All other events - no action needed
         case _ =>
-          // For now, just return the state unchanged with no actions
           (state, Set.empty[Action])
       }
     }
   }
-
-  def apply(): StateProcessor.SingleProcessor = Impl()
 
 }

--- a/src/main/scala/calespiga/processor/OfflineDetectorProcessor.scala
+++ b/src/main/scala/calespiga/processor/OfflineDetectorProcessor.scala
@@ -1,0 +1,28 @@
+package calespiga.processor
+
+import calespiga.model.{Action, Event, State}
+import java.time.Instant
+
+object OfflineDetectorProcessor {
+
+  private final case class Impl(
+      // Configuration will be added later
+  ) extends StateProcessor.SingleProcessor {
+
+    def process(
+        state: State,
+        eventData: Event.EventData,
+        timestamp: Instant
+    ): (State, Set[Action]) = {
+      // TODO: Implement offline detection logic
+      eventData match {
+        case _ =>
+          // For now, just return the state unchanged with no actions
+          (state, Set.empty[Action])
+      }
+    }
+  }
+
+  def apply(): StateProcessor.SingleProcessor = Impl()
+
+}

--- a/src/main/scala/calespiga/processor/StateProcessor.scala
+++ b/src/main/scala/calespiga/processor/StateProcessor.scala
@@ -51,7 +51,7 @@ object StateProcessor {
       temperatureRelatedProcessor =
         TemperatureRelatedProcessor(config.temperatureRelated),
       offlineDetectorProcessor =
-        OfflineDetectorProcessor()
+        OfflineDetectorProcessor(config.offlineDetector)
     )
 
 }

--- a/src/main/scala/calespiga/processor/StateProcessor.scala
+++ b/src/main/scala/calespiga/processor/StateProcessor.scala
@@ -38,9 +38,10 @@ object StateProcessor {
   }
 
   def apply(
-      temperatureRelatedProcessor: SingleProcessor
+      temperatureRelatedProcessor: SingleProcessor,
+      offlineDetectorProcessor: SingleProcessor
   ): StateProcessor = Impl(
-    List(temperatureRelatedProcessor)
+    List(temperatureRelatedProcessor, offlineDetectorProcessor)
   )
 
   def apply(
@@ -48,7 +49,9 @@ object StateProcessor {
   ): StateProcessor =
     this.apply(
       temperatureRelatedProcessor =
-        TemperatureRelatedProcessor(config.temperatureRelated)
+        TemperatureRelatedProcessor(config.temperatureRelated),
+      offlineDetectorProcessor =
+        OfflineDetectorProcessor()
     )
 
 }

--- a/src/test/scala/calespiga/processor/OfflineDetectorProcessorSuite.scala
+++ b/src/test/scala/calespiga/processor/OfflineDetectorProcessorSuite.scala
@@ -1,36 +1,170 @@
 package calespiga.processor
 
 import munit.FunSuite
-import calespiga.model.{Action, Event, State}
+import calespiga.model.{Action, Event, State, Switch}
+import calespiga.config.OfflineDetectorConfig
 import java.time.Instant
+import scala.concurrent.duration._
 
 class OfflineDetectorProcessorSuite extends FunSuite {
 
   private val now = Instant.parse("2023-08-17T10:00:00Z")
-  private val emptyState = calespiga.model.Fixture.state
+  private val testState = calespiga.model.Fixture.state
+  
+  private val testConfig = OfflineDetectorConfig(
+    timeoutDuration = 5.minutes,
+    temperaturesStatusItem = "TemperaturesMicroControladorEstat"
+  )
 
-  test("OfflineDetectorProcessor should process any event without changing state") {
-    val sut = OfflineDetectorProcessor()
-    
-    // Test with a simple event
-    val eventData = Event.Temperature.BatteryTemperatureMeasured(25.0)
+  test("OfflineDetectorProcessor should schedule offline timeout on StartupEvent") {
+    val sut = OfflineDetectorProcessor(testConfig)
     
     val (resultState, resultActions) = sut.process(
-      emptyState,
-      eventData,
+      testState,
+      Event.System.StartupEvent,
       now
     )
     
     assertEquals(
       resultState,
-      emptyState,
+      testState,
       "State should remain unchanged"
     )
-    assertEquals(
-      resultActions,
-      Set.empty[Action],
-      "No actions should be produced"
+    
+    assertEquals(resultActions.size, 1, "Should produce exactly one action")
+    
+    val delayedAction = resultActions.collectFirst { case a: Action.Delayed => a }
+    assert(delayedAction.isDefined, "Should produce a Delayed action")
+    assertEquals(delayedAction.get.id, "temperatures-offline-timeout")
+    
+    delayedAction.get.action match {
+      case Action.SetOpenHabItemValue(item, value) =>
+        assertEquals(item, testConfig.temperaturesStatusItem)
+        assertEquals(value, OfflineDetectorProcessor.OFFLINE)
+      case _ => fail("Delayed action should be SetOpenHabItemValue to offline")
+    }
+  }
+
+  test("OfflineDetectorProcessor should set online and reschedule timeout on temperature events") {
+    val sut = OfflineDetectorProcessor(testConfig)
+    
+    val temperatureEvents = List(
+      Event.Temperature.BatteryTemperatureMeasured(25.0),
+      Event.Temperature.BatteryClosetTemperatureMeasured(22.0),
+      Event.Temperature.ElectronicsTemperatureMeasured(30.0),
+      Event.Temperature.ExternalTemperatureMeasured(15.0)
     )
+    
+    temperatureEvents.foreach { eventData =>
+      val (resultState, resultActions) = sut.process(
+        testState,
+        eventData,
+        now
+      )
+      
+      assertEquals(
+        resultState,
+        testState,
+        s"State should remain unchanged for event: $eventData"
+      )
+      
+      assertEquals(resultActions.size, 2, s"Should produce exactly 2 actions for event: $eventData")
+      
+      // Check for set online action
+      val setOnlineAction = resultActions.collectFirst {
+        case Action.SetOpenHabItemValue(item, OfflineDetectorProcessor.ONLINE) if item == testConfig.temperaturesStatusItem => item
+      }
+      assert(setOnlineAction.isDefined, s"Should set status to online for event: $eventData")
+      
+      // Check for new delayed action (automatically cancels previous one)
+      val delayedAction = resultActions.collectFirst { case a: Action.Delayed => a }
+      assert(delayedAction.isDefined, s"Should schedule new timeout for event: $eventData")
+      assertEquals(delayedAction.get.id, "temperatures-offline-timeout")
+      
+      // Verify the delayed action sets status to OFFLINE
+      delayedAction.get.action match {
+        case Action.SetOpenHabItemValue(item, value) =>
+          assertEquals(item, testConfig.temperaturesStatusItem, s"Delayed action should target correct item for event: $eventData")
+          assertEquals(value, OfflineDetectorProcessor.OFFLINE, s"Delayed action should set status to offline for event: $eventData")
+        case _ => fail(s"Delayed action should be SetOpenHabItemValue to offline for event: $eventData")
+      }
+    }
+  }
+
+  test("OfflineDetectorProcessor should set online and reschedule timeout on fan events") {
+    val sut = OfflineDetectorProcessor(testConfig)
+    
+    val fanEvents = List(
+      Event.Temperature.Fans.BatteryFanSwitchReported(Switch.On),
+      Event.Temperature.Fans.BatteryFanSwitchReported(Switch.Off),
+      Event.Temperature.Fans.ElectronicsFanSwitchReported(Switch.On),
+      Event.Temperature.Fans.ElectronicsFanSwitchReported(Switch.Off)
+    )
+    
+    fanEvents.foreach { eventData =>
+      val (resultState, resultActions) = sut.process(
+        testState,
+        eventData,
+        now
+      )
+      
+      assertEquals(
+        resultState,
+        testState,
+        s"State should remain unchanged for event: $eventData"
+      )
+      
+      assertEquals(resultActions.size, 2, s"Should produce exactly 2 actions for event: $eventData")
+      
+      // Check for set online action
+      val setOnlineAction = resultActions.collectFirst {
+        case Action.SetOpenHabItemValue(item, OfflineDetectorProcessor.ONLINE) if item == testConfig.temperaturesStatusItem => item
+      }
+      assert(setOnlineAction.isDefined, s"Should set status to online for event: $eventData")
+      
+      // Check for new delayed action (automatically cancels previous one)
+      val delayedAction = resultActions.collectFirst { case a: Action.Delayed => a }
+      assert(delayedAction.isDefined, s"Should schedule new timeout for event: $eventData")
+      assertEquals(delayedAction.get.id, "temperatures-offline-timeout")
+      
+      // Verify the delayed action sets status to OFFLINE
+      delayedAction.get.action match {
+        case Action.SetOpenHabItemValue(item, value) =>
+          assertEquals(item, testConfig.temperaturesStatusItem, s"Delayed action should target correct item for event: $eventData")
+          assertEquals(value, OfflineDetectorProcessor.OFFLINE, s"Delayed action should set status to offline for event: $eventData")
+        case _ => fail(s"Delayed action should be SetOpenHabItemValue to offline for event: $eventData")
+      }
+    }
+  }
+
+  test("OfflineDetectorProcessor should ignore non-microcontroller events") {
+    val sut = OfflineDetectorProcessor(testConfig)
+    
+    val nonMicrocontrollerEvents = List(
+      Event.Temperature.GoalTemperatureChanged(21.0),
+      Event.Temperature.Fans.FanManagementChanged(Switch.On),
+      Event.Temperature.Fans.BatteryFanSwitchManualChanged(Switch.On),
+      Event.Temperature.Fans.ElectronicsFanSwitchManualChanged(Switch.Off)
+    )
+    
+    nonMicrocontrollerEvents.foreach { eventData =>
+      val (resultState, resultActions) = sut.process(
+        testState,
+        eventData,
+        now
+      )
+      
+      assertEquals(
+        resultState,
+        testState,
+        s"State should remain unchanged for event: $eventData"
+      )
+      assertEquals(
+        resultActions,
+        Set.empty[Action],
+        s"No actions should be produced for non-microcontroller event: $eventData"
+      )
+    }
   }
 
 }

--- a/src/test/scala/calespiga/processor/OfflineDetectorProcessorSuite.scala
+++ b/src/test/scala/calespiga/processor/OfflineDetectorProcessorSuite.scala
@@ -10,150 +10,210 @@ class OfflineDetectorProcessorSuite extends FunSuite {
 
   private val now = Instant.parse("2023-08-17T10:00:00Z")
   private val testState = calespiga.model.Fixture.state
-  
+
   private val testConfig = OfflineDetectorConfig(
     timeoutDuration = 5.minutes,
-    temperaturesStatusItem = "TemperaturesMicroControladorEstat"
+    temperaturesStatusItem = "TemperaturesMicroControladorEstat",
+    onlineText = "En línia",
+    offlineText = "Fora de línia"
   )
 
-  test("OfflineDetectorProcessor should schedule offline timeout on StartupEvent") {
+  test(
+    "OfflineDetectorProcessor should schedule offline timeout on StartupEvent"
+  ) {
     val sut = OfflineDetectorProcessor(testConfig)
-    
+
     val (resultState, resultActions) = sut.process(
       testState,
       Event.System.StartupEvent,
       now
     )
-    
+
     assertEquals(
       resultState,
       testState,
       "State should remain unchanged"
     )
-    
+
     assertEquals(resultActions.size, 1, "Should produce exactly one action")
-    
-    val delayedAction = resultActions.collectFirst { case a: Action.Delayed => a }
+
+    val delayedAction = resultActions.collectFirst { case a: Action.Delayed =>
+      a
+    }
     assert(delayedAction.isDefined, "Should produce a Delayed action")
     assertEquals(delayedAction.get.id, "temperatures-offline-timeout")
-    
+
     delayedAction.get.action match {
       case Action.SetOpenHabItemValue(item, value) =>
         assertEquals(item, testConfig.temperaturesStatusItem)
-        assertEquals(value, OfflineDetectorProcessor.OFFLINE)
+        assertEquals(value, testConfig.offlineText)
       case _ => fail("Delayed action should be SetOpenHabItemValue to offline")
     }
   }
 
-  test("OfflineDetectorProcessor should set online and reschedule timeout on temperature events") {
+  test(
+    "OfflineDetectorProcessor should set online and reschedule timeout on temperature events"
+  ) {
     val sut = OfflineDetectorProcessor(testConfig)
-    
+
     val temperatureEvents = List(
       Event.Temperature.BatteryTemperatureMeasured(25.0),
       Event.Temperature.BatteryClosetTemperatureMeasured(22.0),
       Event.Temperature.ElectronicsTemperatureMeasured(30.0),
       Event.Temperature.ExternalTemperatureMeasured(15.0)
     )
-    
+
     temperatureEvents.foreach { eventData =>
       val (resultState, resultActions) = sut.process(
         testState,
         eventData,
         now
       )
-      
+
       assertEquals(
         resultState,
         testState,
         s"State should remain unchanged for event: $eventData"
       )
-      
-      assertEquals(resultActions.size, 2, s"Should produce exactly 2 actions for event: $eventData")
-      
+
+      assertEquals(
+        resultActions.size,
+        2,
+        s"Should produce exactly 2 actions for event: $eventData"
+      )
+
       // Check for set online action
       val setOnlineAction = resultActions.collectFirst {
-        case Action.SetOpenHabItemValue(item, OfflineDetectorProcessor.ONLINE) if item == testConfig.temperaturesStatusItem => item
+        case Action.SetOpenHabItemValue(item, testConfig.onlineText)
+            if item == testConfig.temperaturesStatusItem =>
+          item
       }
-      assert(setOnlineAction.isDefined, s"Should set status to online for event: $eventData")
-      
+      assert(
+        setOnlineAction.isDefined,
+        s"Should set status to online for event: $eventData"
+      )
+
       // Check for new delayed action (automatically cancels previous one)
-      val delayedAction = resultActions.collectFirst { case a: Action.Delayed => a }
-      assert(delayedAction.isDefined, s"Should schedule new timeout for event: $eventData")
+      val delayedAction = resultActions.collectFirst { case a: Action.Delayed =>
+        a
+      }
+      assert(
+        delayedAction.isDefined,
+        s"Should schedule new timeout for event: $eventData"
+      )
       assertEquals(delayedAction.get.id, "temperatures-offline-timeout")
-      
+
       // Verify the delayed action sets status to OFFLINE
       delayedAction.get.action match {
         case Action.SetOpenHabItemValue(item, value) =>
-          assertEquals(item, testConfig.temperaturesStatusItem, s"Delayed action should target correct item for event: $eventData")
-          assertEquals(value, OfflineDetectorProcessor.OFFLINE, s"Delayed action should set status to offline for event: $eventData")
-        case _ => fail(s"Delayed action should be SetOpenHabItemValue to offline for event: $eventData")
+          assertEquals(
+            item,
+            testConfig.temperaturesStatusItem,
+            s"Delayed action should target correct item for event: $eventData"
+          )
+          assertEquals(
+            value,
+            testConfig.offlineText,
+            s"Delayed action should set status to offline for event: $eventData"
+          )
+        case _ =>
+          fail(
+            s"Delayed action should be SetOpenHabItemValue to offline for event: $eventData"
+          )
       }
     }
   }
 
-  test("OfflineDetectorProcessor should set online and reschedule timeout on fan events") {
+  test(
+    "OfflineDetectorProcessor should set online and reschedule timeout on fan events"
+  ) {
     val sut = OfflineDetectorProcessor(testConfig)
-    
+
     val fanEvents = List(
       Event.Temperature.Fans.BatteryFanSwitchReported(Switch.On),
       Event.Temperature.Fans.BatteryFanSwitchReported(Switch.Off),
       Event.Temperature.Fans.ElectronicsFanSwitchReported(Switch.On),
       Event.Temperature.Fans.ElectronicsFanSwitchReported(Switch.Off)
     )
-    
+
     fanEvents.foreach { eventData =>
       val (resultState, resultActions) = sut.process(
         testState,
         eventData,
         now
       )
-      
+
       assertEquals(
         resultState,
         testState,
         s"State should remain unchanged for event: $eventData"
       )
-      
-      assertEquals(resultActions.size, 2, s"Should produce exactly 2 actions for event: $eventData")
-      
+
+      assertEquals(
+        resultActions.size,
+        2,
+        s"Should produce exactly 2 actions for event: $eventData"
+      )
+
       // Check for set online action
       val setOnlineAction = resultActions.collectFirst {
-        case Action.SetOpenHabItemValue(item, OfflineDetectorProcessor.ONLINE) if item == testConfig.temperaturesStatusItem => item
+        case Action.SetOpenHabItemValue(item, testConfig.onlineText)
+            if item == testConfig.temperaturesStatusItem =>
+          item
       }
-      assert(setOnlineAction.isDefined, s"Should set status to online for event: $eventData")
-      
+      assert(
+        setOnlineAction.isDefined,
+        s"Should set status to online for event: $eventData"
+      )
+
       // Check for new delayed action (automatically cancels previous one)
-      val delayedAction = resultActions.collectFirst { case a: Action.Delayed => a }
-      assert(delayedAction.isDefined, s"Should schedule new timeout for event: $eventData")
+      val delayedAction = resultActions.collectFirst { case a: Action.Delayed =>
+        a
+      }
+      assert(
+        delayedAction.isDefined,
+        s"Should schedule new timeout for event: $eventData"
+      )
       assertEquals(delayedAction.get.id, "temperatures-offline-timeout")
-      
+
       // Verify the delayed action sets status to OFFLINE
       delayedAction.get.action match {
         case Action.SetOpenHabItemValue(item, value) =>
-          assertEquals(item, testConfig.temperaturesStatusItem, s"Delayed action should target correct item for event: $eventData")
-          assertEquals(value, OfflineDetectorProcessor.OFFLINE, s"Delayed action should set status to offline for event: $eventData")
-        case _ => fail(s"Delayed action should be SetOpenHabItemValue to offline for event: $eventData")
+          assertEquals(
+            item,
+            testConfig.temperaturesStatusItem,
+            s"Delayed action should target correct item for event: $eventData"
+          )
+          assertEquals(
+            value,
+            testConfig.offlineText,
+            s"Delayed action should set status to offline for event: $eventData"
+          )
+        case _ =>
+          fail(
+            s"Delayed action should be SetOpenHabItemValue to offline for event: $eventData"
+          )
       }
     }
   }
 
   test("OfflineDetectorProcessor should ignore non-microcontroller events") {
     val sut = OfflineDetectorProcessor(testConfig)
-    
+
     val nonMicrocontrollerEvents = List(
       Event.Temperature.GoalTemperatureChanged(21.0),
       Event.Temperature.Fans.FanManagementChanged(Switch.On),
       Event.Temperature.Fans.BatteryFanSwitchManualChanged(Switch.On),
       Event.Temperature.Fans.ElectronicsFanSwitchManualChanged(Switch.Off)
     )
-    
+
     nonMicrocontrollerEvents.foreach { eventData =>
       val (resultState, resultActions) = sut.process(
         testState,
         eventData,
         now
       )
-      
+
       assertEquals(
         resultState,
         testState,

--- a/src/test/scala/calespiga/processor/OfflineDetectorProcessorSuite.scala
+++ b/src/test/scala/calespiga/processor/OfflineDetectorProcessorSuite.scala
@@ -1,0 +1,36 @@
+package calespiga.processor
+
+import munit.FunSuite
+import calespiga.model.{Action, Event, State}
+import java.time.Instant
+
+class OfflineDetectorProcessorSuite extends FunSuite {
+
+  private val now = Instant.parse("2023-08-17T10:00:00Z")
+  private val emptyState = calespiga.model.Fixture.state
+
+  test("OfflineDetectorProcessor should process any event without changing state") {
+    val sut = OfflineDetectorProcessor()
+    
+    // Test with a simple event
+    val eventData = Event.Temperature.BatteryTemperatureMeasured(25.0)
+    
+    val (resultState, resultActions) = sut.process(
+      emptyState,
+      eventData,
+      now
+    )
+    
+    assertEquals(
+      resultState,
+      emptyState,
+      "State should remain unchanged"
+    )
+    assertEquals(
+      resultActions,
+      Set.empty[Action],
+      "No actions should be produced"
+    )
+  }
+
+}

--- a/src/test/scala/calespiga/processor/RemoteStateActionProducerSuite.scala
+++ b/src/test/scala/calespiga/processor/RemoteStateActionProducerSuite.scala
@@ -63,19 +63,19 @@ class RemoteStateActionProducerSuite extends FunSuite {
   }
 
   test(
-    "produceActionsForCommand - no inconsistency, sets online and cancels timeout"
+    "produceActionsForCommand - no inconsistency, sets synchronized and cancels timeout"
   ) {
     val remoteState: RemoteState[Switch.Status] =
       RemoteState(Switch.Off, Switch.On, None)
 
     val actions = producer.produceActionsForCommand(remoteState, now)
 
-    val setOnlineAction = actions.collectFirst {
-      case Action.SetOpenHabItemValue(item, "Online")
+    val setSynchronizedAction = actions.collectFirst {
+      case Action.SetOpenHabItemValue(item, RemoteStateActionProducer.SYNCHRONIZED)
           if item == inconsistencyUIItem =>
         item
     }
-    assert(setOnlineAction.isDefined, "Should set inconsistency item to Online")
+    assert(setSynchronizedAction.isDefined, "Should set inconsistency item to Synchronized")
 
     val cancelAction = actions.collectFirst { case a: Action.Cancel => a }
     assert(cancelAction.isDefined, "Should cancel timeout")
@@ -83,7 +83,7 @@ class RemoteStateActionProducerSuite extends FunSuite {
   }
 
   test(
-    "produceActionsForCommand - recent inconsistency, sets online and schedules timeout"
+    "produceActionsForCommand - recent inconsistency, sets synchronized and schedules timeout"
   ) {
     val inconsistencyStart =
       now.minusSeconds(30) // 30 seconds ago, less than 2 minutes timeout
@@ -92,20 +92,20 @@ class RemoteStateActionProducerSuite extends FunSuite {
 
     val actions = producer.produceActionsForCommand(remoteState, now)
 
-    val setOnlineAction = actions.collectFirst {
-      case Action.SetOpenHabItemValue(item, "Online")
+    val setSynchronizedAction = actions.collectFirst {
+      case Action.SetOpenHabItemValue(item, RemoteStateActionProducer.SYNCHRONIZED)
           if item == inconsistencyUIItem =>
         item
     }
-    assert(setOnlineAction.isDefined, "Should set inconsistency item to Online")
+    assert(setSynchronizedAction.isDefined, "Should set inconsistency item to Synchronized")
 
     val delayedAction = actions.collectFirst { case a: Action.Delayed => a }
     assert(delayedAction.isDefined, "Should schedule timeout")
     assertEquals(delayedAction.get.id, s"$id-timeout")
 
-    // Check the delayed action sets offline
+    // Check the delayed action sets not synchronized
     delayedAction.get.action match {
-      case Action.SetOpenHabItemValue(item, "Offline")
+      case Action.SetOpenHabItemValue(item, RemoteStateActionProducer.NOT_SYNCHRONIZED)
           if item == inconsistencyUIItem =>
         // Verify delay is approximately correct (timeout - elapsed time)
         val expectedDelay = timeoutInterval - 30.seconds
@@ -117,12 +117,12 @@ class RemoteStateActionProducerSuite extends FunSuite {
           delayedAction.get.delay.toSeconds <= expectedDelay.toSeconds + 1,
           "Delay should be approximately correct (upper bound)"
         )
-      case _ => fail("Delayed action should set inconsistency item to Offline")
+      case _ => fail("Delayed action should set inconsistency item to Not Synchronized")
     }
   }
 
   test(
-    "produceActionsForCommand - old inconsistency past timeout, sets offline and cancels timeout"
+    "produceActionsForCommand - old inconsistency past timeout, sets not synchronized and cancels timeout"
   ) {
     val inconsistencyStart =
       now.minusSeconds(180) // 3 minutes ago, past 2 minutes timeout
@@ -131,14 +131,14 @@ class RemoteStateActionProducerSuite extends FunSuite {
 
     val actions = producer.produceActionsForCommand(remoteState, now)
 
-    val setOfflineAction = actions.collectFirst {
-      case Action.SetOpenHabItemValue(item, "Offline")
+    val setNotSynchronizedAction = actions.collectFirst {
+      case Action.SetOpenHabItemValue(item, RemoteStateActionProducer.NOT_SYNCHRONIZED)
           if item == inconsistencyUIItem =>
         item
     }
     assert(
-      setOfflineAction.isDefined,
-      "Should set inconsistency item to Offline"
+      setNotSynchronizedAction.isDefined,
+      "Should set inconsistency item to Not Synchronized"
     )
 
     val cancelAction = actions.collectFirst { case a: Action.Cancel => a }
@@ -163,19 +163,19 @@ class RemoteStateActionProducerSuite extends FunSuite {
   }
 
   test(
-    "produceActionsForConfirmed - no inconsistency, sets online and cancels timeout"
+    "produceActionsForConfirmed - no inconsistency, sets synchronized and cancels timeout"
   ) {
     val remoteState: RemoteState[Switch.Status] =
       RemoteState(Switch.On, Switch.Off, None)
 
     val actions = producer.produceActionsForConfirmed(remoteState, now)
 
-    val setOnlineAction = actions.collectFirst {
-      case Action.SetOpenHabItemValue(item, "Online")
+    val setSynchronizedAction = actions.collectFirst {
+      case Action.SetOpenHabItemValue(item, RemoteStateActionProducer.SYNCHRONIZED)
           if item == inconsistencyUIItem =>
         item
     }
-    assert(setOnlineAction.isDefined, "Should set inconsistency item to Online")
+    assert(setSynchronizedAction.isDefined, "Should set inconsistency item to Synchronized")
 
     val cancelAction = actions.collectFirst { case a: Action.Cancel => a }
     assert(cancelAction.isDefined, "Should cancel timeout")
@@ -183,7 +183,7 @@ class RemoteStateActionProducerSuite extends FunSuite {
   }
 
   test(
-    "produceActionsForConfirmed - recent inconsistency, sets online and schedules timeout"
+    "produceActionsForConfirmed - recent inconsistency, sets synchronized and schedules timeout"
   ) {
     val inconsistencyStart =
       now.minusSeconds(45) // 45 seconds ago, less than 2 minutes timeout
@@ -192,20 +192,20 @@ class RemoteStateActionProducerSuite extends FunSuite {
 
     val actions = producer.produceActionsForConfirmed(remoteState, now)
 
-    val setOnlineAction = actions.collectFirst {
-      case Action.SetOpenHabItemValue(item, "Online")
+    val setSynchronizedAction = actions.collectFirst {
+      case Action.SetOpenHabItemValue(item, RemoteStateActionProducer.SYNCHRONIZED)
           if item == inconsistencyUIItem =>
         item
     }
-    assert(setOnlineAction.isDefined, "Should set inconsistency item to Online")
+    assert(setSynchronizedAction.isDefined, "Should set inconsistency item to Synchronized")
 
     val delayedAction = actions.collectFirst { case a: Action.Delayed => a }
     assert(delayedAction.isDefined, "Should schedule timeout")
     assertEquals(delayedAction.get.id, s"$id-timeout")
 
-    // Check the delayed action sets offline
+    // Check the delayed action sets not synchronized
     delayedAction.get.action match {
-      case Action.SetOpenHabItemValue(item, "Offline")
+      case Action.SetOpenHabItemValue(item, RemoteStateActionProducer.NOT_SYNCHRONIZED)
           if item == inconsistencyUIItem =>
         // Verify delay is approximately correct (timeout - elapsed time)
         val expectedDelay = timeoutInterval - 45.seconds
@@ -217,12 +217,12 @@ class RemoteStateActionProducerSuite extends FunSuite {
           delayedAction.get.delay.toSeconds <= expectedDelay.toSeconds + 1,
           "Delay should be approximately correct (upper bound)"
         )
-      case _ => fail("Delayed action should set inconsistency item to Offline")
+      case _ => fail("Delayed action should set inconsistency item to Not Synchronized")
     }
   }
 
   test(
-    "produceActionsForConfirmed - old inconsistency past timeout, sets offline and cancels timeout"
+    "produceActionsForConfirmed - old inconsistency past timeout, sets not synchronized and cancels timeout"
   ) {
     val inconsistencyStart =
       now.minusSeconds(150) // 2.5 minutes ago, past 2 minutes timeout
@@ -231,14 +231,14 @@ class RemoteStateActionProducerSuite extends FunSuite {
 
     val actions = producer.produceActionsForConfirmed(remoteState, now)
 
-    val setOfflineAction = actions.collectFirst {
-      case Action.SetOpenHabItemValue(item, "Offline")
+    val setNotSynchronizedAction = actions.collectFirst {
+      case Action.SetOpenHabItemValue(item, RemoteStateActionProducer.NOT_SYNCHRONIZED)
           if item == inconsistencyUIItem =>
         item
     }
     assert(
-      setOfflineAction.isDefined,
-      "Should set inconsistency item to Offline"
+      setNotSynchronizedAction.isDefined,
+      "Should set inconsistency item to Not Synchronized"
     )
 
     val cancelAction = actions.collectFirst { case a: Action.Cancel => a }

--- a/src/test/scala/calespiga/processor/RemoteStateActionProducerSuite.scala
+++ b/src/test/scala/calespiga/processor/RemoteStateActionProducerSuite.scala
@@ -71,11 +71,16 @@ class RemoteStateActionProducerSuite extends FunSuite {
     val actions = producer.produceActionsForCommand(remoteState, now)
 
     val setSynchronizedAction = actions.collectFirst {
-      case Action.SetOpenHabItemValue(item, RemoteStateActionProducer.SYNCHRONIZED)
-          if item == inconsistencyUIItem =>
+      case Action.SetOpenHabItemValue(
+            item,
+            RemoteStateActionProducer.SYNCHRONIZED
+          ) if item == inconsistencyUIItem =>
         item
     }
-    assert(setSynchronizedAction.isDefined, "Should set inconsistency item to Synchronized")
+    assert(
+      setSynchronizedAction.isDefined,
+      "Should set inconsistency item to Synchronized"
+    )
 
     val cancelAction = actions.collectFirst { case a: Action.Cancel => a }
     assert(cancelAction.isDefined, "Should cancel timeout")
@@ -93,11 +98,16 @@ class RemoteStateActionProducerSuite extends FunSuite {
     val actions = producer.produceActionsForCommand(remoteState, now)
 
     val setSynchronizedAction = actions.collectFirst {
-      case Action.SetOpenHabItemValue(item, RemoteStateActionProducer.SYNCHRONIZED)
-          if item == inconsistencyUIItem =>
+      case Action.SetOpenHabItemValue(
+            item,
+            RemoteStateActionProducer.SYNCHRONIZED
+          ) if item == inconsistencyUIItem =>
         item
     }
-    assert(setSynchronizedAction.isDefined, "Should set inconsistency item to Synchronized")
+    assert(
+      setSynchronizedAction.isDefined,
+      "Should set inconsistency item to Synchronized"
+    )
 
     val delayedAction = actions.collectFirst { case a: Action.Delayed => a }
     assert(delayedAction.isDefined, "Should schedule timeout")
@@ -105,8 +115,10 @@ class RemoteStateActionProducerSuite extends FunSuite {
 
     // Check the delayed action sets not synchronized
     delayedAction.get.action match {
-      case Action.SetOpenHabItemValue(item, RemoteStateActionProducer.NOT_SYNCHRONIZED)
-          if item == inconsistencyUIItem =>
+      case Action.SetOpenHabItemValue(
+            item,
+            RemoteStateActionProducer.NOT_SYNCHRONIZED
+          ) if item == inconsistencyUIItem =>
         // Verify delay is approximately correct (timeout - elapsed time)
         val expectedDelay = timeoutInterval - 30.seconds
         assert(
@@ -117,7 +129,8 @@ class RemoteStateActionProducerSuite extends FunSuite {
           delayedAction.get.delay.toSeconds <= expectedDelay.toSeconds + 1,
           "Delay should be approximately correct (upper bound)"
         )
-      case _ => fail("Delayed action should set inconsistency item to Not Synchronized")
+      case _ =>
+        fail("Delayed action should set inconsistency item to Not Synchronized")
     }
   }
 
@@ -132,8 +145,10 @@ class RemoteStateActionProducerSuite extends FunSuite {
     val actions = producer.produceActionsForCommand(remoteState, now)
 
     val setNotSynchronizedAction = actions.collectFirst {
-      case Action.SetOpenHabItemValue(item, RemoteStateActionProducer.NOT_SYNCHRONIZED)
-          if item == inconsistencyUIItem =>
+      case Action.SetOpenHabItemValue(
+            item,
+            RemoteStateActionProducer.NOT_SYNCHRONIZED
+          ) if item == inconsistencyUIItem =>
         item
     }
     assert(
@@ -171,11 +186,16 @@ class RemoteStateActionProducerSuite extends FunSuite {
     val actions = producer.produceActionsForConfirmed(remoteState, now)
 
     val setSynchronizedAction = actions.collectFirst {
-      case Action.SetOpenHabItemValue(item, RemoteStateActionProducer.SYNCHRONIZED)
-          if item == inconsistencyUIItem =>
+      case Action.SetOpenHabItemValue(
+            item,
+            RemoteStateActionProducer.SYNCHRONIZED
+          ) if item == inconsistencyUIItem =>
         item
     }
-    assert(setSynchronizedAction.isDefined, "Should set inconsistency item to Synchronized")
+    assert(
+      setSynchronizedAction.isDefined,
+      "Should set inconsistency item to Synchronized"
+    )
 
     val cancelAction = actions.collectFirst { case a: Action.Cancel => a }
     assert(cancelAction.isDefined, "Should cancel timeout")
@@ -193,11 +213,16 @@ class RemoteStateActionProducerSuite extends FunSuite {
     val actions = producer.produceActionsForConfirmed(remoteState, now)
 
     val setSynchronizedAction = actions.collectFirst {
-      case Action.SetOpenHabItemValue(item, RemoteStateActionProducer.SYNCHRONIZED)
-          if item == inconsistencyUIItem =>
+      case Action.SetOpenHabItemValue(
+            item,
+            RemoteStateActionProducer.SYNCHRONIZED
+          ) if item == inconsistencyUIItem =>
         item
     }
-    assert(setSynchronizedAction.isDefined, "Should set inconsistency item to Synchronized")
+    assert(
+      setSynchronizedAction.isDefined,
+      "Should set inconsistency item to Synchronized"
+    )
 
     val delayedAction = actions.collectFirst { case a: Action.Delayed => a }
     assert(delayedAction.isDefined, "Should schedule timeout")
@@ -205,8 +230,10 @@ class RemoteStateActionProducerSuite extends FunSuite {
 
     // Check the delayed action sets not synchronized
     delayedAction.get.action match {
-      case Action.SetOpenHabItemValue(item, RemoteStateActionProducer.NOT_SYNCHRONIZED)
-          if item == inconsistencyUIItem =>
+      case Action.SetOpenHabItemValue(
+            item,
+            RemoteStateActionProducer.NOT_SYNCHRONIZED
+          ) if item == inconsistencyUIItem =>
         // Verify delay is approximately correct (timeout - elapsed time)
         val expectedDelay = timeoutInterval - 45.seconds
         assert(
@@ -217,7 +244,8 @@ class RemoteStateActionProducerSuite extends FunSuite {
           delayedAction.get.delay.toSeconds <= expectedDelay.toSeconds + 1,
           "Delay should be approximately correct (upper bound)"
         )
-      case _ => fail("Delayed action should set inconsistency item to Not Synchronized")
+      case _ =>
+        fail("Delayed action should set inconsistency item to Not Synchronized")
     }
   }
 
@@ -232,8 +260,10 @@ class RemoteStateActionProducerSuite extends FunSuite {
     val actions = producer.produceActionsForConfirmed(remoteState, now)
 
     val setNotSynchronizedAction = actions.collectFirst {
-      case Action.SetOpenHabItemValue(item, RemoteStateActionProducer.NOT_SYNCHRONIZED)
-          if item == inconsistencyUIItem =>
+      case Action.SetOpenHabItemValue(
+            item,
+            RemoteStateActionProducer.NOT_SYNCHRONIZED
+          ) if item == inconsistencyUIItem =>
         item
     }
     assert(

--- a/src/test/scala/calespiga/processor/StateProcessorSuite.scala
+++ b/src/test/scala/calespiga/processor/StateProcessorSuite.scala
@@ -18,8 +18,9 @@ class StateProcessorSuite extends CatsEffectSuite {
         }
       val offlineDetectorProcessor: SingleProcessor =
         (state, _, _) => (state, Set.empty)
-      
-      val sut = StateProcessor(temperatureRelatedProcessor, offlineDetectorProcessor)
+
+      val sut =
+        StateProcessor(temperatureRelatedProcessor, offlineDetectorProcessor)
       assertEquals(
         sut.process(Fixture.state, event),
         (Fixture.state, Set.empty),

--- a/src/test/scala/calespiga/processor/StateProcessorSuite.scala
+++ b/src/test/scala/calespiga/processor/StateProcessorSuite.scala
@@ -16,14 +16,19 @@ class StateProcessorSuite extends CatsEffectSuite {
           executed = true
           (state, Set.empty)
         }
-      val sut = StateProcessor(temperatureRelatedProcessor)
+      val offlineDetectorProcessor: SingleProcessor =
+        (state, _, _) => (state, Set.empty)
+      
+      val sut = StateProcessor(temperatureRelatedProcessor, offlineDetectorProcessor)
       assertEquals(
         sut.process(Fixture.state, event),
-        (Fixture.state, Set.empty)
+        (Fixture.state, Set.empty),
+        s"Processing event: $event"
       )
       assertEquals(
         executed,
-        true
+        true,
+        s"TemperatureRelatedProcessor should be executed for event: $event"
       )
     }
   }


### PR DESCRIPTION
This PR adds a new processor whose purpose is to detect if a microcontroller has not been sending events for some time and flag it. Currently only events from one micro are available, but they will grow, so it makes sense to ahve a generic processor for this that can be extended later.