### PR TITLE
[Bugfix] Use app id for automerge and fix bot name

### DIFF
--- a/.github/workflows/auto-merge-steward.yml
+++ b/.github/workflows/auto-merge-steward.yml
@@ -8,7 +8,7 @@ permissions:
 jobs:
   automerge:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.user.login == 'scala-steward-sgabalda'
+    if: github.actor == 'scala-steward-sgabalda[bot]' && github.event.sender.id == 234083034
     steps:
       - name: Generate token
         id: generate-token


### PR DESCRIPTION
This Pr fixes  (or tires to, we will see) the automerge feature. It uses the right bot name, and also uses the app id to ensure no username spoofing is done.