### PR TITLE
[FEATURE] Offline detector with state representation for Grid and Battery

### DIFF
--- a/oh/items/smart-home-state.items
+++ b/oh/items/smart-home-state.items
@@ -77,6 +77,7 @@ String XarxaManualConnexioSHS "Connexió manual xarxa" // manual-switch-item
 String XarxaActorsConexioSHS "Raó connexió" // connection-reason-item
 String XarxaSincronitzacioSHS "Sincronització xarxa"  // sync-status-item
 String XarxaTarifaSHS "Tarifa xarxa"                 // tariff-item
+String XarxaMicroControladorEstatSHS "Estat microcontrolador xarxa"
 
 /*
 ----------------------

--- a/oh/sitemaps/shs.sitemap
+++ b/oh/sitemaps/shs.sitemap
@@ -86,6 +86,7 @@ sitemap shs label="Ca l'espiga SHS" {
             Text item=XarxaActorsConexioSHS icon="switch" label="Raó connexió: [%s]"
             Text item=XarxaSincronitzacioSHS icon="time" label="Sincronització [%s]"
             Text item=XarxaTarifaSHS icon="price" label="Tarifa: [%s]"
+            Text item=XarxaMicroControladorEstatSHS icon="receiver" label="Estat microcontrolador xarxa: [%s]"
         }
     }
 

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -180,6 +180,7 @@ processor {
         id = "grid-processor"
         tariff-item = "XarxaTarifaSHS"
         online-status-item = "XarxaMicroControladorEstatSHS"
+        offline-notification = "El dispositiu de control de la xarxa no respon"
     }
 
     battery {
@@ -189,5 +190,6 @@ processor {
         medium-charge-tariff-item = "XarxaBateriaCarregarMediumSHS"
         online-status-item = "XarxaBateriaMicroControladorEstatSHS"
         id = "battery-processor"
+        offline-notification = "El dispositiu de control de la bateria no respon"
     }
 }

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -179,6 +179,7 @@ processor {
         resend-interval = 20 seconds
         id = "grid-processor"
         tariff-item = "XarxaTarifaSHS"
+        online-status-item = "XarxaMicroControladorEstatSHS"
     }
 
     battery {

--- a/src/main/scala/calespiga/config/ApplicationConfig.scala
+++ b/src/main/scala/calespiga/config/ApplicationConfig.scala
@@ -186,7 +186,8 @@ final case class GridConfig(
     reasonItem: String,
     resendInterval: FiniteDuration,
     id: String,
-    tariffItem: String
+    tariffItem: String,
+    onlineStatusItem: String
 ) derives ConfigReader
 
 final case class PowerProductionConfig(

--- a/src/main/scala/calespiga/config/ApplicationConfig.scala
+++ b/src/main/scala/calespiga/config/ApplicationConfig.scala
@@ -63,6 +63,7 @@ final case class BatteryConfig(
     lowChargeTariffItem: String,
     mediumChargeTariffItem: String,
     onlineStatusItem: String,
+    offlineNotification: String,
     id: String
 ) derives ConfigReader
 
@@ -187,7 +188,8 @@ final case class GridConfig(
     resendInterval: FiniteDuration,
     id: String,
     tariffItem: String,
-    onlineStatusItem: String
+    onlineStatusItem: String,
+    offlineNotification: String
 ) derives ConfigReader
 
 final case class PowerProductionConfig(

--- a/src/main/scala/calespiga/model/Event.scala
+++ b/src/main/scala/calespiga/model/Event.scala
@@ -36,6 +36,10 @@ object Event {
 
     // Event triggered when the system starts and state is restored from persistence
     case object StartupEvent extends SystemData
+
+    case class OfflineDetected(id: String)
+        extends FeedbackEventData
+        with SystemData
   }
 
   object FeatureFlagEvents {

--- a/src/main/scala/calespiga/model/OfflineOnlineSignal.scala
+++ b/src/main/scala/calespiga/model/OfflineOnlineSignal.scala
@@ -1,0 +1,27 @@
+package calespiga.model
+
+import io.circe._
+import sttp.tapir.Schema
+
+enum OfflineOnlineSignal(val label: String) {
+  case Online extends OfflineOnlineSignal("online")
+  case Offline extends OfflineOnlineSignal("offline")
+}
+
+object OfflineOnlineSignal {
+  implicit val encoder: Encoder[OfflineOnlineSignal] = Encoder.instance {
+    case Online  => Json.fromString("online")
+    case Offline => Json.fromString("offline")
+  }
+
+  implicit val decoder: Decoder[OfflineOnlineSignal] =
+    Decoder.decodeString.emap {
+      case s if s.equalsIgnoreCase("online") =>
+        Right(OfflineOnlineSignal.Online)
+      case s if s.equalsIgnoreCase("offline") =>
+        Right(OfflineOnlineSignal.Offline)
+      case other => Left(s"Invalid OfflineOnlineSignal: $other")
+    }
+
+  given Schema[OfflineOnlineSignal] = Schema.string
+}

--- a/src/main/scala/calespiga/model/State.scala
+++ b/src/main/scala/calespiga/model/State.scala
@@ -105,7 +105,8 @@ object State {
       lastCommandSent: Option[GridSignal.ControllerState] = None,
       devicesRequestedConnection: Set[GridSignal.ActorsConnecting] = Set.empty,
       lastSyncing: Option[java.time.Instant] = None,
-      currentTariff: Option[GridTariff] = None
+      currentTariff: Option[GridTariff] = None,
+      online: Option[OfflineOnlineSignal] = None
   )
   object Grid:
     given schema: Schema[Grid] = derived[
@@ -115,7 +116,8 @@ object State {
   case class Battery(
       status: Option[BatteryStatus] = None,
       lowChargeTariff: Option[BatteryChargeTariff] = None,
-      mediumChargeTariff: Option[BatteryChargeTariff] = None
+      mediumChargeTariff: Option[BatteryChargeTariff] = None,
+      online: Option[OfflineOnlineSignal] = None
   )
 
   case class FeatureFlags(

--- a/src/main/scala/calespiga/processor/StateProcessor.scala
+++ b/src/main/scala/calespiga/processor/StateProcessor.scala
@@ -71,7 +71,12 @@ object StateProcessor {
         config.offlineDetector,
         config.syncDetector
       ).toEffectful,
-      GridProcessor(config.grid, config.syncDetector, gridManager).toEffectful,
+      GridProcessor(
+        config.grid,
+        config.syncDetector,
+        gridManager,
+        config.offlineDetector
+      ).toEffectful,
       BatteryProcessor(
         config.battery,
         gridManager,

--- a/src/main/scala/calespiga/processor/battery/BatteryOfflineDetector.scala
+++ b/src/main/scala/calespiga/processor/battery/BatteryOfflineDetector.scala
@@ -17,13 +17,15 @@ private[battery] object BatteryOfflineDetector {
   def apply(
       offlineConfig: OfflineDetectorConfig,
       batteryId: String,
-      onlineStatusItem: String
+      onlineStatusItem: String,
+      messageOffline: String
   ): SingleProcessor =
     OfflineDetector(
       offlineConfig,
       batteryId,
       eventMatcher,
       onlineStatusItem,
-      (state, online) => state.modify(_.battery.online).setTo(Some(online))
+      (state, online) => state.modify(_.battery.online).setTo(Some(online)),
+      Some(messageOffline)
     )
 }

--- a/src/main/scala/calespiga/processor/battery/BatteryProcessor.scala
+++ b/src/main/scala/calespiga/processor/battery/BatteryProcessor.scala
@@ -17,7 +17,8 @@ object BatteryProcessor {
         BatteryOfflineDetector(
           offlineConfig,
           config.id,
-          config.onlineStatusItem
+          config.onlineStatusItem,
+          config.offlineNotification
         )
       )
       .andThen(

--- a/src/main/scala/calespiga/processor/grid/GridOfflineDetector.scala
+++ b/src/main/scala/calespiga/processor/grid/GridOfflineDetector.scala
@@ -1,4 +1,4 @@
-package calespiga.processor.battery
+package calespiga.processor.grid
 
 import calespiga.config.OfflineDetectorConfig
 import calespiga.processor.SingleProcessor
@@ -6,12 +6,12 @@ import calespiga.processor.utils.OfflineDetector
 import calespiga.model.Event
 import com.softwaremill.quicklens.*
 
-private[battery] object BatteryOfflineDetector {
+private[grid] object GridOfflineDetector {
 
   private val eventMatcher: Event.EventData => Boolean = {
-    case Event.Battery.BatteryStatusReported(_) => true
-    case Event.System.StartupEvent              => true
-    case _                                      => false
+    case Event.Grid.GridConnectionStatusReported(_) => true
+    case Event.System.StartupEvent                  => true
+    case _                                          => false
   }
 
   def apply(
@@ -24,6 +24,6 @@ private[battery] object BatteryOfflineDetector {
       batteryId,
       eventMatcher,
       onlineStatusItem,
-      (state, online) => state.modify(_.battery.online).setTo(Some(online))
+      (state, online) => state.modify(_.grid.online).setTo(Some(online))
     )
 }

--- a/src/main/scala/calespiga/processor/grid/GridOfflineDetector.scala
+++ b/src/main/scala/calespiga/processor/grid/GridOfflineDetector.scala
@@ -16,14 +16,16 @@ private[grid] object GridOfflineDetector {
 
   def apply(
       offlineConfig: OfflineDetectorConfig,
-      batteryId: String,
-      onlineStatusItem: String
+      gridId: String,
+      onlineStatusItem: String,
+      offlineNotification: String
   ): SingleProcessor =
     OfflineDetector(
       offlineConfig,
-      batteryId,
+      gridId,
       eventMatcher,
       onlineStatusItem,
-      (state, online) => state.modify(_.grid.online).setTo(Some(online))
+      (state, online) => state.modify(_.grid.online).setTo(Some(online)),
+      Some(offlineNotification)
     )
 }

--- a/src/main/scala/calespiga/processor/grid/GridProcessor.scala
+++ b/src/main/scala/calespiga/processor/grid/GridProcessor.scala
@@ -19,6 +19,11 @@ object GridProcessor {
       .andThen(GridConnectionProcessor(config, manager))
       .andThen(GridSyncDetector(syncConfig, config.id, config.syncStatusItem))
       .andThen(
-        GridOfflineDetector(offlineConfig, config.id, config.onlineStatusItem, config.offlineNotification)
+        GridOfflineDetector(
+          offlineConfig,
+          config.id,
+          config.onlineStatusItem,
+          config.offlineNotification
+        )
       )
 }

--- a/src/main/scala/calespiga/processor/grid/GridProcessor.scala
+++ b/src/main/scala/calespiga/processor/grid/GridProcessor.scala
@@ -3,6 +3,7 @@ package calespiga.processor.grid
 import calespiga.config.GridConfig
 import calespiga.config.SyncDetectorConfig
 import calespiga.processor.SingleProcessor
+import calespiga.config.OfflineDetectorConfig
 
 /** Aggregate processor for the grid connection relay.
   */
@@ -11,9 +12,13 @@ object GridProcessor {
   def apply(
       config: GridConfig,
       syncConfig: SyncDetectorConfig,
-      manager: GridConnectionManager
+      manager: GridConnectionManager,
+      offlineConfig: OfflineDetectorConfig
   ): SingleProcessor =
     GridTariffProcessor(config)
       .andThen(GridConnectionProcessor(config, manager))
       .andThen(GridSyncDetector(syncConfig, config.id, config.syncStatusItem))
+      .andThen(
+        GridOfflineDetector(offlineConfig, config.id, config.onlineStatusItem)
+      )
 }

--- a/src/main/scala/calespiga/processor/grid/GridProcessor.scala
+++ b/src/main/scala/calespiga/processor/grid/GridProcessor.scala
@@ -19,6 +19,6 @@ object GridProcessor {
       .andThen(GridConnectionProcessor(config, manager))
       .andThen(GridSyncDetector(syncConfig, config.id, config.syncStatusItem))
       .andThen(
-        GridOfflineDetector(offlineConfig, config.id, config.onlineStatusItem)
+        GridOfflineDetector(offlineConfig, config.id, config.onlineStatusItem, config.offlineNotification)
       )
 }

--- a/src/main/scala/calespiga/processor/utils/OfflineDetector.scala
+++ b/src/main/scala/calespiga/processor/utils/OfflineDetector.scala
@@ -9,24 +9,33 @@ import calespiga.model.OfflineOnlineSignal
 import calespiga.model.Action.SendFeedbackEvent
 import calespiga.model.Action.SendNotification
 
-/**
-  * Generic offline detector processor that can be used for any component by providing a matching function for the 
-  * relevant events and the actions to set online/offline status. 
-  * It handles scheduling the offline timeout and resetting it on relevant events.
+/** Generic offline detector processor that can be used for any component by
+  * providing a matching function for the relevant events and the actions to set
+  * online/offline status. It handles scheduling the offline timeout and
+  * resetting it on relevant events.
   */
 object OfflineDetector {
 
   val ID_SUFFIX = "-offline-detector"
 
-  /**
-    * Creates an offline detector processor.
+  /** Creates an offline detector processor.
     *
-    * @param config Configuration for the offline detector, including timeout duration and online/offline text.
-    * @param id Identifier for the component being monitored (used for scheduling and feedback events). 
-    * @param eventMatcher Function to match relevant events that indicate the component is online.
-    * @param statusItem The UI item to update with online/offline status.
-    * @param offlineStateFieldModifier Function to modify the state when the component is offline. If not provided, the state is not modified.
-    * @param messageOffline Optional message to display when the component goes offline. If not provided, no notification is sent on offline.
+    * @param config
+    *   Configuration for the offline detector, including timeout duration and
+    *   online/offline text.
+    * @param id
+    *   Identifier for the component being monitored (used for scheduling and
+    *   feedback events).
+    * @param eventMatcher
+    *   Function to match relevant events that indicate the component is online.
+    * @param statusItem
+    *   The UI item to update with online/offline status.
+    * @param offlineStateFieldModifier
+    *   Function to modify the state when the component is offline. If not
+    *   provided, the state is not modified.
+    * @param messageOffline
+    *   Optional message to display when the component goes offline. If not
+    *   provided, no notification is sent on offline.
     * @return
     */
   def apply(

--- a/src/main/scala/calespiga/processor/utils/OfflineDetector.scala
+++ b/src/main/scala/calespiga/processor/utils/OfflineDetector.scala
@@ -7,25 +7,44 @@ import calespiga.processor.SingleProcessor
 import calespiga.model.Event.System.OfflineDetected
 import calespiga.model.OfflineOnlineSignal
 import calespiga.model.Action.SendFeedbackEvent
+import calespiga.model.Action.SendNotification
 
+/**
+  * Generic offline detector processor that can be used for any component by providing a matching function for the 
+  * relevant events and the actions to set online/offline status. 
+  * It handles scheduling the offline timeout and resetting it on relevant events.
+  */
 object OfflineDetector {
 
   val ID_SUFFIX = "-offline-detector"
 
+  /**
+    * Creates an offline detector processor.
+    *
+    * @param config Configuration for the offline detector, including timeout duration and online/offline text.
+    * @param id Identifier for the component being monitored (used for scheduling and feedback events). 
+    * @param eventMatcher Function to match relevant events that indicate the component is online.
+    * @param statusItem The UI item to update with online/offline status.
+    * @param offlineStateFieldModifier Function to modify the state when the component is offline. If not provided, the state is not modified.
+    * @param messageOffline Optional message to display when the component goes offline. If not provided, no notification is sent on offline.
+    * @return
+    */
   def apply(
       config: OfflineDetectorConfig,
       id: String,
       eventMatcher: Event.EventData => Boolean,
       statusItem: String,
       offlineStateFieldModifier: (State, OfflineOnlineSignal) => State =
-        (state, _) => state
+        (state, _) => state,
+      messageOffline: Option[String] = None
   ): SingleProcessor =
     Impl(
       config,
       id + ID_SUFFIX,
       eventMatcher,
       statusItem,
-      offlineStateFieldModifier
+      offlineStateFieldModifier,
+      messageOffline
     )
 
   private final case class Impl(
@@ -33,14 +52,18 @@ object OfflineDetector {
       id: String,
       eventMatcher: Event.EventData => Boolean,
       statusItem: String,
-      offlineStateFieldModifier: (State, OfflineOnlineSignal) => State
+      offlineStateFieldModifier: (State, OfflineOnlineSignal) => State,
+      messageOffline: Option[String]
   ) extends SingleProcessor {
 
-    val offlineAction =
-      Action.SetUIItemValue(
-        statusItem,
-        config.offlineText
-      )
+    val offlineActions =
+      Set(
+        Action.SetUIItemValue(statusItem, config.offlineText)
+      ) ++ (messageOffline match {
+        case Some(message) =>
+          Set(SendNotification(id, message, None))
+        case None => Set.empty[Action]
+      })
 
     val setOnlineAction =
       Action.SetUIItemValue(
@@ -77,7 +100,7 @@ object OfflineDetector {
         case OfflineDetected(offlineId) if offlineId == id =>
           (
             offlineStateFieldModifier(state, OfflineOnlineSignal.Offline),
-            Set(offlineAction)
+            offlineActions
           )
 
         // All other events - no action needed

--- a/src/main/scala/calespiga/processor/utils/OfflineDetector.scala
+++ b/src/main/scala/calespiga/processor/utils/OfflineDetector.scala
@@ -4,6 +4,9 @@ import calespiga.model.{Action, Event, State}
 import calespiga.config.OfflineDetectorConfig
 import java.time.Instant
 import calespiga.processor.SingleProcessor
+import calespiga.model.Event.System.OfflineDetected
+import calespiga.model.OfflineOnlineSignal
+import calespiga.model.Action.SendFeedbackEvent
 
 object OfflineDetector {
 
@@ -13,16 +16,43 @@ object OfflineDetector {
       config: OfflineDetectorConfig,
       id: String,
       eventMatcher: Event.EventData => Boolean,
-      statusItem: String
+      statusItem: String,
+      offlineStateFieldModifier: (State, OfflineOnlineSignal) => State =
+        (state, _) => state
   ): SingleProcessor =
-    Impl(config, id + ID_SUFFIX, eventMatcher, statusItem)
+    Impl(
+      config,
+      id + ID_SUFFIX,
+      eventMatcher,
+      statusItem,
+      offlineStateFieldModifier
+    )
 
   private final case class Impl(
       config: OfflineDetectorConfig,
       id: String,
       eventMatcher: Event.EventData => Boolean,
-      statusItem: String
+      statusItem: String,
+      offlineStateFieldModifier: (State, OfflineOnlineSignal) => State
   ) extends SingleProcessor {
+
+    val offlineAction =
+      Action.SetUIItemValue(
+        statusItem,
+        config.offlineText
+      )
+
+    val setOnlineAction =
+      Action.SetUIItemValue(
+        statusItem,
+        config.onlineText
+      )
+
+    val delayedOfflineAction = Action.Delayed(
+      id,
+      SendFeedbackEvent(OfflineDetected(id)),
+      config.timeoutDuration
+    )
 
     def process(
         state: State,
@@ -32,41 +62,23 @@ object OfflineDetector {
       eventData match {
         // Handle startup event - schedule initial offline timeout
         case Event.System.StartupEvent =>
-          val offlineAction =
-            Action.SetUIItemValue(
-              statusItem,
-              config.offlineText
-            )
-          val delayedOfflineAction = Action.Delayed(
-            id,
-            offlineAction,
-            config.timeoutDuration
-          )
+
           (state, Set(delayedOfflineAction))
 
         // Handle events matching
         case e if eventMatcher(e) =>
 
           // Set status to online immediately
-          val setOnlineAction =
-            Action.SetUIItemValue(
-              statusItem,
-              config.onlineText
-            )
-
-          // Schedule new offline timeout (automatically cancels previous one with same ID)
-          val offlineAction =
-            Action.SetUIItemValue(
-              statusItem,
-              config.offlineText
-            )
-          val newDelayedOfflineAction = Action.Delayed(
-            id,
-            offlineAction,
-            config.timeoutDuration
+          (
+            offlineStateFieldModifier(state, OfflineOnlineSignal.Online),
+            Set(setOnlineAction, delayedOfflineAction)
           )
 
-          (state, Set(setOnlineAction, newDelayedOfflineAction))
+        case OfflineDetected(offlineId) if offlineId == id =>
+          (
+            offlineStateFieldModifier(state, OfflineOnlineSignal.Offline),
+            Set(offlineAction)
+          )
 
         // All other events - no action needed
         case _ =>

--- a/src/test/scala/calespiga/processor/ProcessorConfigHelper.scala
+++ b/src/test/scala/calespiga/processor/ProcessorConfigHelper.scala
@@ -128,7 +128,8 @@ object ProcessorConfigHelper {
     syncStatusItem = "grid/syncStatus",
     reasonItem = "grid/connectionReason",
     resendInterval = 20.seconds,
-    tariffItem = "grid/tariff"
+    tariffItem = "grid/tariff",
+    onlineStatusItem = "grid/onlineStatus"
   )
 
   val batteryConfig: BatteryConfig = BatteryConfig(

--- a/src/test/scala/calespiga/processor/ProcessorConfigHelper.scala
+++ b/src/test/scala/calespiga/processor/ProcessorConfigHelper.scala
@@ -129,7 +129,8 @@ object ProcessorConfigHelper {
     reasonItem = "grid/connectionReason",
     resendInterval = 20.seconds,
     tariffItem = "grid/tariff",
-    onlineStatusItem = "grid/onlineStatus"
+    onlineStatusItem = "grid/onlineStatus",
+    offlineNotification = "El dispositiu de control de la xarxa no respon"
   )
 
   val batteryConfig: BatteryConfig = BatteryConfig(
@@ -138,7 +139,8 @@ object ProcessorConfigHelper {
     lowChargeTariffItem = "grid/batteryLowChargeTariff",
     mediumChargeTariffItem = "grid/batteryMediumChargeTariff",
     onlineStatusItem = "grid/batteryOnlineStatus",
-    id = "battery-processor"
+    id = "battery-processor",
+    offlineNotification = "El dispositiu de control de la bateria no respon"
   )
 
   val processorConfig: ProcessorConfig = ProcessorConfig(

--- a/src/test/scala/calespiga/processor/heater/HeaterOfflineDetectorSuite.scala
+++ b/src/test/scala/calespiga/processor/heater/HeaterOfflineDetectorSuite.scala
@@ -23,7 +23,9 @@ class HeaterOfflineDetectorSuite extends FunSuite {
       Action.SetUIItemValue(statusItem, config.onlineText),
       Action.Delayed(
         id + OfflineDetector.ID_SUFFIX,
-        Action.SetUIItemValue(statusItem, config.offlineText),
+        Action.SendFeedbackEvent(
+          Event.System.OfflineDetected(id + OfflineDetector.ID_SUFFIX)
+        ),
         config.timeoutDuration
       )
     )
@@ -41,7 +43,9 @@ class HeaterOfflineDetectorSuite extends FunSuite {
       Action.SetUIItemValue(statusItem, config.onlineText),
       Action.Delayed(
         id + OfflineDetector.ID_SUFFIX,
-        Action.SetUIItemValue(statusItem, config.offlineText),
+        Action.SendFeedbackEvent(
+          Event.System.OfflineDetected(id + OfflineDetector.ID_SUFFIX)
+        ),
         config.timeoutDuration
       )
     )
@@ -56,7 +60,9 @@ class HeaterOfflineDetectorSuite extends FunSuite {
     val expectedActions: Set[Action] = Set(
       Action.Delayed(
         id + OfflineDetector.ID_SUFFIX,
-        Action.SetUIItemValue(statusItem, config.offlineText),
+        Action.SendFeedbackEvent(
+          Event.System.OfflineDetected(id + OfflineDetector.ID_SUFFIX)
+        ),
         config.timeoutDuration
       )
     )

--- a/src/test/scala/calespiga/processor/temperatures/TemperaturesOfflineDetectorSuite.scala
+++ b/src/test/scala/calespiga/processor/temperatures/TemperaturesOfflineDetectorSuite.scala
@@ -22,7 +22,9 @@ class TemperaturesOfflineDetectorSuite extends FunSuite {
       Action.SetUIItemValue(statusItem, config.onlineText),
       Action.Delayed(
         id + OfflineDetector.ID_SUFFIX,
-        Action.SetUIItemValue(statusItem, config.offlineText),
+        Action.SendFeedbackEvent(
+          Event.System.OfflineDetected(id + OfflineDetector.ID_SUFFIX)
+        ),
         config.timeoutDuration
       )
     )
@@ -38,7 +40,9 @@ class TemperaturesOfflineDetectorSuite extends FunSuite {
       Action.SetUIItemValue(statusItem, config.onlineText),
       Action.Delayed(
         id + OfflineDetector.ID_SUFFIX,
-        Action.SetUIItemValue(statusItem, config.offlineText),
+        Action.SendFeedbackEvent(
+          Event.System.OfflineDetected(id + OfflineDetector.ID_SUFFIX)
+        ),
         config.timeoutDuration
       )
     )
@@ -53,7 +57,9 @@ class TemperaturesOfflineDetectorSuite extends FunSuite {
     val expectedActions: Set[Action] = Set(
       Action.Delayed(
         id + OfflineDetector.ID_SUFFIX,
-        Action.SetUIItemValue(statusItem, config.offlineText),
+        Action.SendFeedbackEvent(
+          Event.System.OfflineDetected(id + OfflineDetector.ID_SUFFIX)
+        ),
         config.timeoutDuration
       )
     )

--- a/src/test/scala/calespiga/processor/utils/OfflineDetectorSuite.scala
+++ b/src/test/scala/calespiga/processor/utils/OfflineDetectorSuite.scala
@@ -103,4 +103,33 @@ class OfflineDetectorSuite extends FunSuite {
       s"Expected action $expectedOfflineAction in $actions"
     )
   }
+
+  test("OfflineDetected event sends NO notification if not configured") {
+    val state = State()
+    val offlineEvent = Event.System.OfflineDetected(id)
+
+    val (_, actions) = detector.process(state, offlineEvent, now)
+
+    assert(
+      !actions.find({
+        case Action.SendNotification(_, _, _) => true
+        case _                              => false
+      }).isDefined,
+      s"Expected NO notification action in $actions"
+    )
+  }
+
+  test("OfflineDetected event sends notification if configured") {
+    val state = State()
+    val offlineEvent = Event.System.OfflineDetected(id)
+    val notificationMessage = "Device is offline"
+    val detector = OfflineDetector(config, originalId, matcher, statusItem, messageOffline = Some(notificationMessage))
+
+    val (_, actions) = detector.process(state, offlineEvent, now)
+
+    assert(
+      actions.contains(Action.SendNotification(id, notificationMessage, None)),
+      s"Expected notification action in $actions"
+    )
+  }
 }

--- a/src/test/scala/calespiga/processor/utils/OfflineDetectorSuite.scala
+++ b/src/test/scala/calespiga/processor/utils/OfflineDetectorSuite.scala
@@ -111,10 +111,12 @@ class OfflineDetectorSuite extends FunSuite {
     val (_, actions) = detector.process(state, offlineEvent, now)
 
     assert(
-      !actions.find({
-        case Action.SendNotification(_, _, _) => true
-        case _                              => false
-      }).isDefined,
+      !actions
+        .find({
+          case Action.SendNotification(_, _, _) => true
+          case _                                => false
+        })
+        .isDefined,
       s"Expected NO notification action in $actions"
     )
   }
@@ -123,7 +125,13 @@ class OfflineDetectorSuite extends FunSuite {
     val state = State()
     val offlineEvent = Event.System.OfflineDetected(id)
     val notificationMessage = "Device is offline"
-    val detector = OfflineDetector(config, originalId, matcher, statusItem, messageOffline = Some(notificationMessage))
+    val detector = OfflineDetector(
+      config,
+      originalId,
+      matcher,
+      statusItem,
+      messageOffline = Some(notificationMessage)
+    )
 
     val (_, actions) = detector.process(state, offlineEvent, now)
 

--- a/src/test/scala/calespiga/processor/utils/OfflineDetectorSuite.scala
+++ b/src/test/scala/calespiga/processor/utils/OfflineDetectorSuite.scala
@@ -33,7 +33,9 @@ class OfflineDetectorSuite extends FunSuite {
       Action.SetUIItemValue(statusItem, config.onlineText),
       Action.Delayed(
         id,
-        Action.SetUIItemValue(statusItem, config.offlineText),
+        Action.SendFeedbackEvent(
+          Event.System.OfflineDetected(originalId + OfflineDetector.ID_SUFFIX)
+        ),
         config.timeoutDuration
       )
     )
@@ -48,7 +50,9 @@ class OfflineDetectorSuite extends FunSuite {
     val expectedActions: Set[Action] = Set(
       Action.Delayed(
         id,
-        Action.SetUIItemValue(statusItem, config.offlineText),
+        Action.SendFeedbackEvent(
+          Event.System.OfflineDetected(originalId + OfflineDetector.ID_SUFFIX)
+        ),
         config.timeoutDuration
       )
     )
@@ -62,5 +66,41 @@ class OfflineDetectorSuite extends FunSuite {
     val (newState, actions) = detector.process(state, unrelatedEvent, now)
     assertEquals(newState, state)
     assertEquals(actions, Set.empty)
+  }
+
+  test("OfflineDetected event updates state with provided function") {
+    var stateModifierCalled = false
+    var capturedSignal: calespiga.model.OfflineOnlineSignal = null
+
+    val stateModifier: (State, calespiga.model.OfflineOnlineSignal) => State =
+      (state, signal) => {
+        stateModifierCalled = true
+        capturedSignal = signal
+        state
+      }
+
+    val detectorWithModifier =
+      OfflineDetector(config, originalId, matcher, statusItem, stateModifier)
+    val state = State()
+    val offlineEvent = Event.System.OfflineDetected(id)
+
+    val (_, _) = detectorWithModifier.process(state, offlineEvent, now)
+
+    assert(stateModifierCalled, "State modifier was not called")
+    assertEquals(capturedSignal, calespiga.model.OfflineOnlineSignal.Offline)
+  }
+
+  test("OfflineDetected event sets UI item to offline") {
+    val state = State()
+    val offlineEvent = Event.System.OfflineDetected(id)
+
+    val (_, actions) = detector.process(state, offlineEvent, now)
+
+    val expectedOfflineAction =
+      Action.SetUIItemValue(statusItem, config.offlineText)
+    assert(
+      actions.contains(expectedOfflineAction),
+      s"Expected action $expectedOfflineAction in $actions"
+    )
   }
 }


### PR DESCRIPTION
Currently the OfflineDetector logic only schedules changes in the UI. This limits the ability of having in the state a representation of the Online/Offline status of an external device or sensor.

With this PR, the OfflineDetector does not schedule the change of an UI item, but schedules a feedback event, that once receiveid is used to:
- change the UI item
- update the state if configured to do so
- send a notification if configured to do so

In this same PR it is configured this behavior for the Grid and the Battery. This is done because in next PRs the Dynamic Power logic will be improved to use the Grid power in addition to the photovoltaic power, and for using it is necessary to know if the Grid device and the battery device are online or not.