### PR TITLE
[CHORE] Make timezone configurable by env var

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -19,6 +19,8 @@ NOTIFICATION_EMAIL_SUBJECT_TAG=[Smart Home]
 # Java runtime options (optimized for Raspberry Pi 3B+ with 1GB RAM)
 JAVA_OPTS=-Xmx256m -Xms128m -XX:+UseG1GC -XX:+UseContainerSupport
 
+TIMEZONE=Europe/Madrid
+
 # MQTT Configuration
 MQTT_BROKER_HOST=localhost
 MQTT_BROKER_PORT=1883

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1,3 +1,8 @@
+system{
+    timezone = "Europe/Madrid"
+    timezone = ${?TIMEZONE}
+}
+
 http-server-config{
     host = "0.0.0.0"
     host = ${?HTTP_SERVER_HOST}

--- a/src/main/scala/calespiga/Main.scala
+++ b/src/main/scala/calespiga/Main.scala
@@ -144,7 +144,7 @@ object Main extends IOApp.Simple {
           HealthStatusManager.Component.StatePersistence
         )
       )
-      zoneId = ZoneId.systemDefault()
+      zoneId = ZoneId.of(appConfig.system.timezone)
       processor = StateProcessor(appConfig.processor, mqttBlacklist, zoneId)
       _ <- Endpoints(stateRef, healthStatusManager, appConfig.httpServerConfig)
       powerSource <- powerDeps(appConfig.powerProduction, zoneId)

--- a/src/main/scala/calespiga/config/ApplicationConfig.scala
+++ b/src/main/scala/calespiga/config/ApplicationConfig.scala
@@ -5,12 +5,17 @@ import pureconfig.ConfigReader
 import scala.concurrent.duration.FiniteDuration
 
 final case class ApplicationConfig(
+    system: SystemConfig,
     httpServerConfig: HttpServerConfig,
     mqttConfig: MqttConfig,
     uiConfig: UIConfig,
     powerProduction: PowerProductionConfig,
     statePersistenceConfig: StatePersistenceConfig,
     processor: ProcessorConfig
+) derives ConfigReader
+
+final case class SystemConfig(
+    timezone: String
 ) derives ConfigReader
 
 final case class HttpServerConfig(


### PR DESCRIPTION
The timezone was obtained getting the system default. It turns out that docker by default takes UTC, limiting the ability to use a local timezone if not specified in the docker itslef. To avoid relying on docker, the app loads a timezone from the configuration file.