### PR TITLE
[BUGFIX] Fix item names mismatch and potential loop in UI changes

### DIFF
--- a/src/main/scala/calespiga/model/Event.scala
+++ b/src/main/scala/calespiga/model/Event.scala
@@ -174,11 +174,11 @@ object Event {
     @InputEventMqtt("battery/level/status")
     case class BatteryStatusReported(status: BatteryStatus) extends BatteryData
 
-    @InputEventOHItem("XarxaCarregarBateriaLowSHS")
+    @InputEventOHItem("XarxaBateriaCarregarLowSHS")
     case class BatteryChargeLowTariffChanged(tariff: BatteryChargeTariff)
         extends BatteryData
 
-    @InputEventOHItem("XarxaCarregarBateriaMediumSHS")
+    @InputEventOHItem("XarxaBateriaCarregarMediumSHS")
     case class BatteryChargeMediumTariffChanged(tariff: BatteryChargeTariff)
         extends BatteryData
   }

--- a/src/main/scala/calespiga/processor/battery/BatteryChargeProcessor.scala
+++ b/src/main/scala/calespiga/processor/battery/BatteryChargeProcessor.scala
@@ -85,22 +85,14 @@ private[battery] object BatteryChargeProcessor {
         case Event.Battery.BatteryChargeLowTariffChanged(tariff) =>
           val newState =
             state.modify(_.battery.lowChargeTariff).setTo(Some(tariff))
-          val actions =
-            Set[Action](
-              Action.SetUIItemValue(config.lowChargeTariffItem, tariff.label)
-            )
 
-          updateStateAndReconnect(newState, actions)
+          updateStateAndReconnect(newState, Set.empty)
 
         case Event.Battery.BatteryChargeMediumTariffChanged(tariff) =>
           val newState =
             state.modify(_.battery.mediumChargeTariff).setTo(Some(tariff))
-          val actions =
-            Set[Action](
-              Action.SetUIItemValue(config.mediumChargeTariffItem, tariff.label)
-            )
 
-          updateStateAndReconnect(newState, actions)
+          updateStateAndReconnect(newState, Set.empty)
 
         case Event.Grid.GridTariffChanged(_) =>
           val shouldConnect = shouldChargeBattery(state)

--- a/src/test/scala/calespiga/processor/battery/BatteryProcessorSuite.scala
+++ b/src/test/scala/calespiga/processor/battery/BatteryProcessorSuite.scala
@@ -108,7 +108,7 @@ class BatteryProcessorSuite extends FunSuite {
     )
   }
 
-  test("Battery low tariff change updates state and UI") {
+  test("Battery low tariff change updates state") {
     val manager = new ManagerStub()
     val p = processor(manager)
 
@@ -124,7 +124,27 @@ class BatteryProcessorSuite extends FunSuite {
     )
     assertEquals(
       actions,
-      Set[Action](Action.SetUIItemValue(config.lowChargeTariffItem, "vall"))
+      Set.empty
+    )
+  }
+
+  test("Battery medium tariff change updates state") {
+    val manager = new ManagerStub()
+    val p = processor(manager)
+
+    val (newState, actions) = p.process(
+      baseState,
+      Event.Battery.BatteryChargeMediumTariffChanged(BatteryChargeTariff.Vall),
+      now
+    )
+
+    assertEquals(
+      newState.battery.mediumChargeTariff,
+      Some(BatteryChargeTariff.Vall)
+    )
+    assertEquals(
+      actions,
+      Set.empty
     )
   }
 
@@ -245,24 +265,7 @@ class BatteryProcessorSuite extends FunSuite {
         val (stateAfter, actions) =
           p.process(initialState, event, now)
 
-        val expectedActions = s.status match
-          case BatteryStatus.Low =>
-            Set[Action](
-              Action.SetUIItemValue(config.lowChargeTariffItem, s.tariff.label)
-            )
-          case BatteryStatus.Medium =>
-            Set[Action](
-              Action.SetUIItemValue(
-                config.mediumChargeTariffItem,
-                s.tariff.label
-              )
-            )
-          case BatteryStatus.High =>
-            Set[Action](
-              Action.SetUIItemValue(config.lowChargeTariffItem, s.tariff.label)
-            )
-
-        assertEquals(actions, expectedActions)
+        assertEquals(actions, Set.empty)
 
         assertManager(manager, s.shouldConnect(gridTariff))
       }
@@ -292,27 +295,7 @@ class BatteryProcessorSuite extends FunSuite {
         val (stateAfter, actions) =
           p.process(initialState, event, now)
 
-        val expectedActions = s.status match
-          case BatteryStatus.Low =>
-            Set[Action](
-              Action.SetUIItemValue(
-                config.mediumChargeTariffItem,
-                s.tariff.label
-              )
-            )
-          case BatteryStatus.Medium =>
-            Set[Action](
-              Action.SetUIItemValue(config.lowChargeTariffItem, s.tariff.label)
-            )
-          case BatteryStatus.High =>
-            Set[Action](
-              Action.SetUIItemValue(
-                config.mediumChargeTariffItem,
-                s.tariff.label
-              )
-            )
-
-        assertEquals(actions, expectedActions)
+        assertEquals(actions, Set.empty)
 
         // Key assertion: should NOT connect regardless of tariff logic
         assertManager(manager, shouldConnect = false)


### PR DESCRIPTION
After identifying that the battery charge using the grid on battery low is notworking for the SHS, this PR solves the problem. There was a mismatch of the item names, that caused the state to not being update on the UI changes. Also, it has been detected that if in the event of an UI item changed, the same item is changed by SHS it can be an infinite loop.