### PR TITLE
[FEATURE] Car charger manual user interaction

### DIFF
--- a/oh/items/smart-home-state.items
+++ b/oh/items/smart-home-state.items
@@ -97,7 +97,9 @@ CAR CHARGER
 */
 String CarChargerTitle "Vehicle Elèctric"
 String CarChargerStatusSHS "Estat carregador"
+String CarChargerSetSHS "Mode carregador"
 String CarChargerMicroControladorEstatSHS "Estat microcontrolador carregador"
+String CarChargerSincronitzacioSHS "Estat sincronització carregador"
 String CarChargerChargingStatusSHS "Estat càrrega carregador"
 Number CarChargerPowerSHS "Potència carregador"
 Number CarChargerEnergiaAvuiSHS "Energia carregada avui"
@@ -120,4 +122,5 @@ String EstufaInfrarrojosMicroControladorEstatSHS "Estat microcontrolador estufa"
 String CalentadorHabilitatsSHS "Habilitar calentador per SHS"
 String EstufaInfrarrojosEnabledSHS "Habilitar estufa infrarrojos per SHS"
 String XarxaEnabledSHS "Habilitar xarxa per SHS"
+String CarChargerHabilitatsSHS "Habilitar carregador per SHS"
 

--- a/oh/sitemaps/shs.sitemap
+++ b/oh/sitemaps/shs.sitemap
@@ -103,7 +103,9 @@ sitemap shs label="Ca l'espiga SHS" {
     Text item=CarChargerTitle label="Vehicle Elèctric" icon="electric_car"
     {
         Frame label="Carregador vehicle" {
+            Selection item=CarChargerSetSHS icon="switch" mappings=["off"="Off","on"="On","automatic"="Automàtic"]
             Text item=CarChargerStatusSHS icon="car" label="Estat: [%s]"
+            Text item=CarChargerSincronitzacioSHS icon="time" label="Sincronitzacio [%s]"
             Text item=CarChargerMicroControladorEstatSHS icon="network" label="Estat microcontrolador: [%s]"
             Text item=CarChargerChargingStatusSHS icon="indicator" label="Connexió: [%s]"
             Text item=CarChargerPowerSHS icon="power" label="Potència: [%.0f W]"
@@ -121,6 +123,7 @@ sitemap shs label="Ca l'espiga SHS" {
             Selection item=CalentadorHabilitatsSHS icon="network" label="Control calent. [%s]" mappings=["true"="SHS", "false"="OH"]
             Selection item=EstufaInfrarrojosEnabledSHS icon="network" label="Control estufa infrarrojos [%s]" mappings=["true"="SHS", "false"="OH"]
             Selection item=XarxaEnabledSHS icon="network" label="Control xarxa [%s]" mappings=["true"="SHS", "false"="OH"]
+            Selection item=CarChargerHabilitatsSHS icon="network" label="Control carregador [%s]" mappings=["true"="SHS", "false"="OH"]
         }
     }
 }

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -173,6 +173,8 @@ processor {
         set-infrared-stove-enabled-item = "EstufaInfrarrojosEnabledSHS"
         grid-mqtt-topic = [${processor.grid.mqtt-topic-for-command}]
         set-grid-connection-enabled-item = "XarxaEnabledSHS"
+        car-charger-mqtt-topic = [${processor.car-charger.mqtt-topic-for-command}]
+        set-car-charger-management-item = "CarChargerHabilitatsSHS"
     }
 
     grid {
@@ -204,7 +206,11 @@ processor {
         energy-today-item = "CarChargerEnergiaAvuiSHS"
         charging-status-item = "CarChargerChargingStatusSHS"
         online-status-item = "CarChargerMicroControladorEstatSHS"
+        sync-status-item = "CarChargerSincronitzacioSHS"
         offline-notification = "El dispositiu de control del carregador no respon"
+        mqtt-topic-for-command = "cotxe/carrega/set"
+        resend-interval = 20 seconds
+        last-command-item = "CarChargerSetSHS"
         id = "car-charger-processor"
     }
 }

--- a/src/main/scala/calespiga/config/ApplicationConfig.scala
+++ b/src/main/scala/calespiga/config/ApplicationConfig.scala
@@ -79,7 +79,11 @@ final case class CarChargerConfig(
     energyTodayItem: String,
     chargingStatusItem: String,
     onlineStatusItem: String,
+    syncStatusItem: String,
     offlineNotification: String,
+    mqttTopicForCommand: String,
+    resendInterval: FiniteDuration,
+    lastCommandItem: String,
     id: String
 ) derives ConfigReader
 
@@ -192,7 +196,9 @@ final case class FeatureFlagsConfig(
     infraredStoveMqttTopic: Set[String],
     setInfraredStoveEnabledItem: String,
     gridMqttTopic: Set[String],
-    setGridConnectionEnabledItem: String
+    setGridConnectionEnabledItem: String,
+    carChargerMqttTopic: Set[String],
+    setCarChargerManagementItem: String
 ) derives ConfigReader
 
 final case class GridConfig(

--- a/src/main/scala/calespiga/model/CarChargerSignal.scala
+++ b/src/main/scala/calespiga/model/CarChargerSignal.scala
@@ -1,6 +1,7 @@
 package calespiga.model
 
 import io.circe._
+import sttp.tapir.Schema
 
 object CarChargerSignal {
 
@@ -32,4 +33,33 @@ object CarChargerSignal {
   def controllerStatePower(state: ControllerState): Int = state match
     case Off => 0
     case On  => 1
+
+  // Commands coming from the UI (user intent)
+  sealed trait UserCommand
+  case object TurnOff extends UserCommand
+  case object TurnOn extends UserCommand
+  case object SetAutomatic extends UserCommand
+
+  implicit val userCommandEncoder: Encoder[UserCommand] = Encoder.instance {
+    c => Json.fromString(userCommandToString(c))
+  }
+
+  implicit val userCommandDecoder: Decoder[UserCommand] =
+    Decoder.decodeString.emap {
+      userCommandFromString
+    }
+
+  def userCommandToString(cmd: UserCommand): String = cmd match
+    case TurnOff      => "off"
+    case TurnOn       => "on"
+    case SetAutomatic => "automatic"
+
+  def userCommandFromString(str: String): Either[String, UserCommand] =
+    str.toLowerCase match
+      case "off"       => Right(TurnOff)
+      case "on"        => Right(TurnOn)
+      case "automatic" => Right(SetAutomatic)
+      case other       => Left(s"Invalid CarChargerSignal.UserCommand: $other")
+
+  given Schema[UserCommand] = Schema.string
 }

--- a/src/main/scala/calespiga/model/Event.scala
+++ b/src/main/scala/calespiga/model/Event.scala
@@ -54,6 +54,9 @@ object Event {
     @InputEventOHItem("XarxaEnabledSHS")
     case class SetGridConnectionEnabled(enable: Boolean)
         extends FeatureFlagEvent
+
+    @InputEventOHItem("CarChargerHabilitatsSHS")
+    case class SetCarChargerManagement(enable: Boolean) extends FeatureFlagEvent
   }
 
   object Temperature {
@@ -199,6 +202,11 @@ object Event {
     @InputEventMqtt("cotxe/carrega/energy")
     case class CarChargerAccumulatedEnergyReported(
         totalWh: Float
+    ) extends CarChargerData
+
+    @InputEventOHItem("CarChargerSetSHS")
+    case class CarChargerPowerCommandChanged(
+        command: CarChargerSignal.UserCommand
     ) extends CarChargerData
   }
 

--- a/src/main/scala/calespiga/model/State.scala
+++ b/src/main/scala/calespiga/model/State.scala
@@ -124,6 +124,10 @@ object State {
 
   case class CarCharger(
       switchStatus: Option[CarChargerSignal.ControllerState] = None,
+      lastCommandSent: Option[CarChargerSignal.ControllerState] = None,
+      lastCommandReceived: Option[CarChargerSignal.UserCommand] = None,
+      lastChange: Option[java.time.Instant] = None,
+      lastSyncing: Option[java.time.Instant] = None,
       currentPowerWatts: Option[Float] = None,
       lastEnergyUpdate: Option[java.time.Instant] = None,
       lastAccumulatedEnergyWh: Option[Float] = None,
@@ -136,6 +140,7 @@ object State {
       // to be removed when heater is controlled by SHS
       heaterManagementEnabled: Boolean = false,
       infraredStoveEnabled: Boolean = false,
-      gridConnectionEnabled: Boolean = false
+      gridConnectionEnabled: Boolean = false,
+      carChargerManagementEnabled: Boolean = false
   )
 }

--- a/src/main/scala/calespiga/openhab/annotations/InputOHItemsMapper.scala
+++ b/src/main/scala/calespiga/openhab/annotations/InputOHItemsMapper.scala
@@ -108,6 +108,16 @@ object InputOHItemsMapper {
 
             case tpe
                 if tpe =:= TypeRepr
+                  .of[calespiga.model.CarChargerSignal.UserCommand] =>
+              val convertedValueExpr = '{ (valueStr: String) =>
+                calespiga.model.CarChargerSignal
+                  .userCommandFromString(valueStr)
+                  .getOrElse(calespiga.model.CarChargerSignal.TurnOff)
+              }
+              getNewExpr(convertedValueExpr)
+
+            case tpe
+                if tpe =:= TypeRepr
                   .of[calespiga.model.FanSignal.UserCommand] =>
               val convertedValueExpr = '{ (valueStr: String) =>
                 calespiga.model.FanSignal

--- a/src/main/scala/calespiga/processor/FeatureFlagsProcessor.scala
+++ b/src/main/scala/calespiga/processor/FeatureFlagsProcessor.scala
@@ -40,7 +40,11 @@ object FeatureFlagsProcessor {
                 if (!state.featureFlags.gridConnectionEnabled)
                   config.gridMqttTopic
                 else Set.empty
-              bl ++ heaterBl ++ stoveBl ++ gridBl
+              val carChargerBl =
+                if (!state.featureFlags.carChargerManagementEnabled)
+                  config.carChargerMqttTopic
+                else Set.empty
+              bl ++ heaterBl ++ stoveBl ++ gridBl ++ carChargerBl
             }
             .as(
               (
@@ -57,6 +61,10 @@ object FeatureFlagsProcessor {
                   Action.SetUIItemValue(
                     config.setGridConnectionEnabledItem,
                     state.featureFlags.gridConnectionEnabled.toString
+                  ),
+                  Action.SetUIItemValue(
+                    config.setCarChargerManagementItem,
+                    state.featureFlags.carChargerManagementEnabled.toString
                   )
                 )
               )
@@ -96,6 +104,25 @@ object FeatureFlagsProcessor {
               )
             ) <* logger.info(
             "Infrared stove MQTT feature flag set to " + enable
+          )
+
+        case Event.FeatureFlagEvents.SetCarChargerManagement(enable) =>
+          val modifier = if (enable) { (bl: Set[String]) =>
+            bl -- config.carChargerMqttTopic
+          } else { (bl: Set[String]) =>
+            bl ++ config.carChargerMqttTopic
+          }
+          mqttBlacklist
+            .update(modifier)
+            .as(
+              (
+                state
+                  .modify(_.featureFlags.carChargerManagementEnabled)
+                  .setTo(enable),
+                Set.empty
+              )
+            ) <* logger.info(
+            "Car charger MQTT feature flag set to " + enable
           )
 
         case Event.FeatureFlagEvents.SetGridConnectionEnabled(enable) =>

--- a/src/main/scala/calespiga/processor/StateProcessor.scala
+++ b/src/main/scala/calespiga/processor/StateProcessor.scala
@@ -86,7 +86,8 @@ object StateProcessor {
       CarChargerProcessor(
         config.carCharger,
         zoneId,
-        config.offlineDetector
+        config.offlineDetector,
+        config.syncDetector
       ).toEffectful,
       FeatureFlagsProcessor(mqttBlacklist, config.featureFlags)
     )

--- a/src/main/scala/calespiga/processor/carCharger/CarChargerPowerProcessor.scala
+++ b/src/main/scala/calespiga/processor/carCharger/CarChargerPowerProcessor.scala
@@ -1,0 +1,90 @@
+package calespiga.processor.carCharger
+
+import calespiga.config.CarChargerConfig
+import calespiga.model.{State, Action, Event}
+import calespiga.processor.SingleProcessor
+import calespiga.processor.utils.CommandActions
+import com.softwaremill.quicklens.*
+import java.time.Instant
+
+private[carCharger] object CarChargerPowerProcessor {
+
+  private final case class Impl(config: CarChargerConfig)
+      extends SingleProcessor {
+
+    private val actions =
+      CommandActions[calespiga.model.CarChargerSignal.ControllerState](
+        config.mqttTopicForCommand,
+        config.id,
+        config.resendInterval,
+        calespiga.model.CarChargerSignal.controllerStateToString
+      )
+
+    private def getDefaultCommandToSend(
+        status: calespiga.model.CarChargerSignal.UserCommand
+    ): calespiga.model.CarChargerSignal.ControllerState =
+      status match
+        case calespiga.model.CarChargerSignal.TurnOff =>
+          calespiga.model.CarChargerSignal.Off
+        case calespiga.model.CarChargerSignal.TurnOn =>
+          calespiga.model.CarChargerSignal.On
+        case calespiga.model.CarChargerSignal.SetAutomatic =>
+          calespiga.model.CarChargerSignal.Off
+
+    override def process(
+        state: State,
+        eventData: Event.EventData,
+        timestamp: Instant
+    ): (State, Set[Action]) =
+      eventData match
+
+        case Event.CarCharger.CarChargerPowerCommandChanged(command) =>
+          val commandToSend = getDefaultCommandToSend(command)
+
+          val newState = state
+            .modify(_.carCharger.lastCommandReceived)
+            .setTo(Some(command))
+            .modify(_.carCharger.lastCommandSent)
+            .setTo(Some(commandToSend))
+            .modify(_.carCharger.lastChange)
+            .setTo(Some(timestamp))
+
+          (
+            newState,
+            actions.commandActionWithResend(commandToSend)
+          )
+
+        case Event.System.StartupEvent =>
+          val commandToSend = getDefaultCommandToSend(
+            state.carCharger.lastCommandReceived.getOrElse(
+              calespiga.model.CarChargerSignal.TurnOff
+            )
+          )
+
+          val newState = state
+            .modify(_.carCharger.lastCommandSent)
+            .setTo(Some(commandToSend))
+            .modify(_.carCharger.lastChange)
+            .setTo(Some(timestamp))
+
+          (
+            newState,
+            actions.commandActionWithResend(commandToSend) ++ Set(
+              Action.SetUIItemValue(
+                config.lastCommandItem,
+                calespiga.model.CarChargerSignal.userCommandToString(
+                  state.carCharger.lastCommandReceived.getOrElse(
+                    calespiga.model.CarChargerSignal.TurnOff
+                  )
+                )
+              )
+            )
+          )
+
+        case _ =>
+          (state, Set.empty)
+  }
+
+  def apply(config: CarChargerConfig): SingleProcessor = Impl(config)
+
+}

--- a/src/main/scala/calespiga/processor/carCharger/CarChargerProcessor.scala
+++ b/src/main/scala/calespiga/processor/carCharger/CarChargerProcessor.scala
@@ -11,11 +11,18 @@ object CarChargerProcessor {
   def apply(
       config: CarChargerConfig,
       zone: ZoneId,
-      offlineDetectorConfig: OfflineDetectorConfig
+      offlineDetectorConfig: OfflineDetectorConfig,
+      syncConfig: calespiga.config.SyncDetectorConfig
   ): SingleProcessor =
     CarChargerOfflineDetector(offlineDetectorConfig, config)
       .andThen(
         CarChargerStatusProcessor(config)
+      )
+      .andThen(
+        CarChargerPowerProcessor(config)
+      )
+      .andThen(
+        CarChargerSyncDetector(syncConfig, config.id, config.syncStatusItem)
       )
       .andThen(
         CarChargerEnergyProcessor(config, zone)

--- a/src/main/scala/calespiga/processor/carCharger/CarChargerSyncDetector.scala
+++ b/src/main/scala/calespiga/processor/carCharger/CarChargerSyncDetector.scala
@@ -1,0 +1,46 @@
+package calespiga.processor.carCharger
+
+import calespiga.processor.utils.SyncDetector
+import calespiga.config.SyncDetectorConfig
+import calespiga.model.State
+import com.softwaremill.quicklens.*
+import java.time.Instant
+import calespiga.model.Event
+
+private object CarChargerSyncDetector {
+
+  private def field1ToCheck(state: State) = state.carCharger.lastCommandSent
+
+  private def field2ToCheck(state: State) = state.carCharger.switchStatus
+
+  private def getLastSyncing(state: State) = state.carCharger.lastSyncing
+
+  private def setLastSyncing(state: State, when: Option[Instant]) =
+    state.modify(_.carCharger.lastSyncing).setTo(when)
+
+  private val isEventRelevant: Event.EventData => Boolean = {
+    case Event.CarCharger.CarChargerPowerCommandChanged(_) => true
+    case Event.CarCharger.CarChargerStatusReported(_)      => true
+    case Event.CarCharger.CarChargerPowerReported(_)       => true
+    case Event.System.StartupEvent                         => true
+    case _: Event.Power.PowerProductionReported            => true
+    case _                                                 => false
+  }
+
+  def apply(
+      syncConfig: SyncDetectorConfig,
+      id: String,
+      statusItem: String
+  ): SyncDetector =
+    SyncDetector(
+      syncConfig,
+      id,
+      field1ToCheck,
+      field2ToCheck,
+      getLastSyncing,
+      setLastSyncing,
+      statusItem,
+      isEventRelevant
+    )
+
+}

--- a/src/test/scala/calespiga/processor/FeatureFlagsProcessorSuite.scala
+++ b/src/test/scala/calespiga/processor/FeatureFlagsProcessorSuite.scala
@@ -36,6 +36,9 @@ class FeatureFlagsProcessorSuite extends CatsEffectSuite {
       dummyConfig.gridMqttTopic.foreach { topic =>
         assert(blacklist.contains(topic))
       }
+      dummyConfig.carChargerMqttTopic.foreach { topic =>
+        assert(blacklist.contains(topic))
+      }
       assertEquals(
         actions,
         Set[Action](
@@ -49,6 +52,10 @@ class FeatureFlagsProcessorSuite extends CatsEffectSuite {
           ),
           Action.SetUIItemValue(
             dummyConfig.setGridConnectionEnabledItem,
+            "false"
+          ),
+          Action.SetUIItemValue(
+            dummyConfig.setCarChargerManagementItem,
             "false"
           )
         )
@@ -67,6 +74,8 @@ class FeatureFlagsProcessorSuite extends CatsEffectSuite {
         .setTo(true)
         .modify(_.featureFlags.gridConnectionEnabled)
         .setTo(true)
+        .modify(_.featureFlags.carChargerManagementEnabled)
+        .setTo(true)
       (_, actions) <- processor.process(state, startupEvent, now)
       blacklist <- blacklistRef.get
     } yield {
@@ -84,6 +93,10 @@ class FeatureFlagsProcessorSuite extends CatsEffectSuite {
           ),
           Action.SetUIItemValue(
             dummyConfig.setGridConnectionEnabledItem,
+            "true"
+          ),
+          Action.SetUIItemValue(
+            dummyConfig.setCarChargerManagementItem,
             "true"
           )
         )

--- a/src/test/scala/calespiga/processor/ProcessorConfigHelper.scala
+++ b/src/test/scala/calespiga/processor/ProcessorConfigHelper.scala
@@ -97,7 +97,9 @@ object ProcessorConfigHelper {
       Set("infraredStove/topic1", "infraredStove/topic2"),
     setInfraredStoveEnabledItem = "featureFlags/setInfraredStoveEnabled",
     gridMqttTopic = Set("grid/topic1", "grid/topic2"),
-    setGridConnectionEnabledItem = "featureFlags/setGridConnectionEnabled"
+    setGridConnectionEnabledItem = "featureFlags/setGridConnectionEnabled",
+    carChargerMqttTopic = Set("cotxe/carrega/set"),
+    setCarChargerManagementItem = "featureFlags/setCarChargerManagement"
   )
 
   val powerAvailableProcessorConfig: PowerAvailableProcessorConfig =
@@ -149,7 +151,11 @@ object ProcessorConfigHelper {
     energyTodayItem = "carcharger/energyTodayItem",
     chargingStatusItem = "carcharger/chargingStatusItem",
     onlineStatusItem = "carcharger/onlineStatusItem",
+    syncStatusItem = "carcharger/syncStatusItem",
     offlineNotification = "El dispositiu de control del carregador no respon",
+    mqttTopicForCommand = "dummy/carcharger/command",
+    resendInterval = 20.seconds,
+    lastCommandItem = "carcharger/lastCommand",
     id = "car-charger-processor"
   )
 

--- a/src/test/scala/calespiga/processor/carCharger/CarChargerPowerProcessorSuite.scala
+++ b/src/test/scala/calespiga/processor/carCharger/CarChargerPowerProcessorSuite.scala
@@ -1,0 +1,158 @@
+package calespiga.processor.carCharger
+
+import munit.FunSuite
+import calespiga.model.{State, Action, CarChargerSignal}
+import calespiga.model.Event.CarCharger.*
+import java.time.Instant
+import com.softwaremill.quicklens.*
+import calespiga.processor.ProcessorConfigHelper
+import calespiga.processor.utils.CommandActions
+
+class CarChargerPowerProcessorSuite extends FunSuite {
+
+  private val now = Instant.parse("2024-01-15T10:00:00Z")
+
+  private val config = ProcessorConfigHelper.carCharger
+
+  private def stateWithCarCharger(
+      switchStatus: Option[CarChargerSignal.ControllerState] = None,
+      lastCommandSent: Option[CarChargerSignal.ControllerState] = None,
+      lastCommandReceived: Option[CarChargerSignal.UserCommand] = None,
+      lastChange: Option[Instant] = None
+  ): State =
+    State()
+      .modify(_.carCharger)
+      .setTo(
+        State.CarCharger(
+          switchStatus = switchStatus,
+          lastCommandSent = lastCommandSent,
+          lastCommandReceived = lastCommandReceived,
+          lastChange = lastChange,
+          currentPowerWatts = None,
+          lastEnergyUpdate = None,
+          lastAccumulatedEnergyWh = None,
+          accumulatedAtDayStartWh = None,
+          online = None,
+          chargingStatus = None
+        )
+      )
+
+  test(
+    "CarChargerPowerCommandChanged stores user and controller command, sends correct actions"
+  ) {
+    val initialState = stateWithCarCharger()
+    val event = CarChargerPowerCommandChanged(CarChargerSignal.TurnOn)
+    val processor = CarChargerPowerProcessor(config)
+    val (newState, actions) = processor.process(initialState, event, now)
+
+    assertEquals(
+      newState.carCharger.lastCommandReceived,
+      Some(CarChargerSignal.TurnOn)
+    )
+    assertEquals(newState.carCharger.lastCommandSent, Some(CarChargerSignal.On))
+
+    val expectedActions = Set(
+      Action.SendMqttStringMessage(config.mqttTopicForCommand, "on"),
+      Action.Periodic(
+        config.id + CommandActions.COMMAND_ACTION_SUFFIX,
+        Action.SendMqttStringMessage(config.mqttTopicForCommand, "on"),
+        config.resendInterval
+      )
+    )
+
+    assertEquals(actions, expectedActions)
+  }
+
+  test(
+    "CarChargerPowerCommandChanged SetAutomatic sends Off to microcontroller"
+  ) {
+    val initialState = stateWithCarCharger()
+    val event = CarChargerPowerCommandChanged(CarChargerSignal.SetAutomatic)
+    val processor = CarChargerPowerProcessor(config)
+    val (newState, actions) = processor.process(initialState, event, now)
+
+    assertEquals(
+      newState.carCharger.lastCommandReceived,
+      Some(CarChargerSignal.SetAutomatic)
+    )
+    assertEquals(
+      newState.carCharger.lastCommandSent,
+      Some(CarChargerSignal.Off)
+    )
+
+    val expectedActions = Set(
+      Action.SendMqttStringMessage(config.mqttTopicForCommand, "off"),
+      Action.Periodic(
+        config.id + CommandActions.COMMAND_ACTION_SUFFIX,
+        Action.SendMqttStringMessage(config.mqttTopicForCommand, "off"),
+        config.resendInterval
+      )
+    )
+
+    assertEquals(actions, expectedActions)
+  }
+
+  test("StartupEvent sends last user command or Off if none") {
+    val initialState =
+      stateWithCarCharger(lastCommandReceived = Some(CarChargerSignal.TurnOff))
+    val processor = CarChargerPowerProcessor(config)
+    val (newState, actions) = processor.process(
+      initialState,
+      calespiga.model.Event.System.StartupEvent,
+      now
+    )
+
+    assertEquals(
+      newState.carCharger.lastCommandSent,
+      Some(CarChargerSignal.Off)
+    )
+    assertEquals(newState.carCharger.lastChange, Some(now))
+
+    val expectedActions = Set(
+      Action.SendMqttStringMessage(config.mqttTopicForCommand, "off"),
+      Action.Periodic(
+        config.id + CommandActions.COMMAND_ACTION_SUFFIX,
+        Action.SendMqttStringMessage(config.mqttTopicForCommand, "off"),
+        config.resendInterval
+      ),
+      Action.SetUIItemValue(
+        config.lastCommandItem,
+        CarChargerSignal.userCommandToString(CarChargerSignal.TurnOff)
+      )
+    )
+
+    assertEquals(actions, expectedActions)
+  }
+
+  test("StartupEvent with no previous command sends Off and UI shows off") {
+    val initialState = stateWithCarCharger()
+    val processor = CarChargerPowerProcessor(config)
+    val (newState, actions) = processor.process(
+      initialState,
+      calespiga.model.Event.System.StartupEvent,
+      now
+    )
+
+    assertEquals(
+      newState.carCharger.lastCommandSent,
+      Some(CarChargerSignal.Off)
+    )
+    assertEquals(newState.carCharger.lastChange, Some(now))
+
+    val expectedActions = Set(
+      Action.SendMqttStringMessage(config.mqttTopicForCommand, "off"),
+      Action.Periodic(
+        config.id + CommandActions.COMMAND_ACTION_SUFFIX,
+        Action.SendMqttStringMessage(config.mqttTopicForCommand, "off"),
+        config.resendInterval
+      ),
+      Action.SetUIItemValue(
+        config.lastCommandItem,
+        CarChargerSignal.userCommandToString(CarChargerSignal.TurnOff)
+      )
+    )
+
+    assertEquals(actions, expectedActions)
+  }
+
+}


### PR DESCRIPTION
This PR adds the feature to control from the OH UI the charger to turn it on and off. An automatic option is also added to be used in future PRs. In this one, the OH items, configurations and processors with the logic are implemented to manage the remote controller for the charger, allowing to turn it on or off.

Also a feature flag has been added, to manage the migration of the feature from the current OH rules to the new application.

**Before merging, it is required to:**

- [x] Add the new items to the OH configuration
- [x] Change the logic on OH to ignore the internal logic and react only to the MQTT input topic if the FF is enabled.