### PR TITLE
[FEATURE] Relay for grid in the state

### DIFF
--- a/oh/items/smart-home-state.items
+++ b/oh/items/smart-home-state.items
@@ -76,6 +76,7 @@ String XarxaStatusSHS "Estat connexió xarxa"       // status-item
 String XarxaManualConnexioSHS "Connexió manual xarxa" // manual-switch-item
 String XarxaActorsConexioSHS "Raó connexió" // connection-reason-item
 String XarxaSincronitzacioSHS "Sincronització xarxa"  // sync-status-item
+String XarxaSincronitzacioReleSHS "Sincronització rele xarxa"  // sync-relay-status-item
 String XarxaTarifaSHS "Tarifa xarxa"                 // tariff-item
 String XarxaMicroControladorEstatSHS "Estat microcontrolador xarxa"
 

--- a/oh/sitemaps/shs.sitemap
+++ b/oh/sitemaps/shs.sitemap
@@ -84,7 +84,8 @@ sitemap shs label="Ca l'espiga SHS" {
             Selection item=XarxaManualConnexioSHS icon="switch" mappings=["true"="Connectar", "false"="Desconnectar"]
             Text item=XarxaStatusSHS icon="electric_tower" label="Estat connexió: [%s]"
             Text item=XarxaActorsConexioSHS icon="switch" label="Raó connexió: [%s]"
-            Text item=XarxaSincronitzacioSHS icon="time" label="Sincronització [%s]"
+            Text item=XarxaSincronitzacioSHS icon="time" label="Sincronització connexió: [%s]"
+            Text item=XarxaSincronitzacioReleSHS icon="time" label="Sincronització rele: [%s]"
             Text item=XarxaTarifaSHS icon="price" label="Tarifa: [%s]"
             Text item=XarxaMicroControladorEstatSHS icon="receiver" label="Estat microcontrolador xarxa: [%s]"
         }

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -189,6 +189,8 @@ processor {
         tariff-item = "XarxaTarifaSHS"
         online-status-item = "XarxaMicroControladorEstatSHS"
         offline-notification = "El dispositiu de control de la xarxa no respon"
+        sync-notification = "La connexió a xarxa no està sincronitzada. O el contorlador no funciona, o no hi ha connexió a xarxa"
+        sync-relay-notification = "El relé de control de la xarxa no està sincronitzat. Probablement el controlador no funciona correctament"
     }
 
     battery {

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -183,6 +183,7 @@ processor {
         manual-switch-item = "XarxaManualConnexioSHS"
         reason-item = "XarxaActorsConexioSHS"
         sync-status-item = "XarxaSincronitzacioSHS"
+        sync-relay-status-item = "XarxaSincronitzacioReleSHS"
         resend-interval = 20 seconds
         id = "grid-processor"
         tariff-item = "XarxaTarifaSHS"

--- a/src/main/scala/calespiga/config/ApplicationConfig.scala
+++ b/src/main/scala/calespiga/config/ApplicationConfig.scala
@@ -212,7 +212,9 @@ final case class GridConfig(
     id: String,
     tariffItem: String,
     onlineStatusItem: String,
-    offlineNotification: String
+    offlineNotification: String,
+    syncNotification: String,
+    syncRelayNotification: String
 ) derives ConfigReader
 
 final case class PowerProductionConfig(

--- a/src/main/scala/calespiga/config/ApplicationConfig.scala
+++ b/src/main/scala/calespiga/config/ApplicationConfig.scala
@@ -206,6 +206,7 @@ final case class GridConfig(
     statusItem: String,
     manualSwitchItem: String,
     syncStatusItem: String,
+    syncRelayStatusItem: String,
     reasonItem: String,
     resendInterval: FiniteDuration,
     id: String,

--- a/src/main/scala/calespiga/model/Event.scala
+++ b/src/main/scala/calespiga/model/Event.scala
@@ -163,6 +163,11 @@ object Event {
         status: GridSignal.ControllerState
     ) extends GridData
 
+    @InputEventMqtt("grid/connection/action")
+    case class GridRelayStatusReported(
+        status: GridSignal.ControllerState
+    ) extends GridData
+
     @InputEventOHItem("XarxaManualConnexioSHS")
     case class GridManualConnectionChanged(
         connect: Boolean

--- a/src/main/scala/calespiga/model/State.scala
+++ b/src/main/scala/calespiga/model/State.scala
@@ -103,10 +103,14 @@ object State {
   )
 
   case class Grid(
-      status: Option[GridSignal.ControllerState] = None,
+      statusConnection: Option[GridSignal.ControllerState] =
+        None, // the last status read from the remote grid sensor, used to detect if the grid not connected although the relay may be reporting connected
       lastCommandSent: Option[GridSignal.ControllerState] = None,
+      statusRelay: Option[GridSignal.ControllerState] =
+        None, // the last status received directly from the relay, used to detect if the relay is not responding
+      lastSyncingConnection: Option[java.time.Instant] = None,
+      lastSyncingRelay: Option[java.time.Instant] = None,
       devicesRequestedConnection: Set[GridSignal.ActorsConnecting] = Set.empty,
-      lastSyncing: Option[java.time.Instant] = None,
       currentTariff: Option[GridTariff] = None,
       online: Option[OfflineOnlineSignal] = None
   )

--- a/src/main/scala/calespiga/processor/grid/GridConnectionProcessor.scala
+++ b/src/main/scala/calespiga/processor/grid/GridConnectionProcessor.scala
@@ -23,7 +23,8 @@ private object GridConnectionProcessor {
       case gd: Event.Grid.GridData =>
         gd match {
           case Event.Grid.GridConnectionStatusReported(status) =>
-            val newState = state.modify(_.grid.status).setTo(Some(status))
+            val newState =
+              state.modify(_.grid.statusConnection).setTo(Some(status))
             val actions: Set[Action] = Set(
               Action.SetUIItemValue(
                 config.statusItem,
@@ -37,6 +38,10 @@ private object GridConnectionProcessor {
               manager.requestConnection(GridSignal.Manual, state)
             else
               manager.releaseConnection(GridSignal.Manual, state)
+
+          case Event.Grid.GridRelayStatusReported(status) =>
+            val newState = state.modify(_.grid.statusRelay).setTo(Some(status))
+            (newState, Set.empty)
 
           case _ => (state, Set.empty)
         }

--- a/src/main/scala/calespiga/processor/grid/GridProcessor.scala
+++ b/src/main/scala/calespiga/processor/grid/GridProcessor.scala
@@ -17,12 +17,20 @@ object GridProcessor {
   ): SingleProcessor =
     GridTariffProcessor(config)
       .andThen(GridConnectionProcessor(config, manager))
-      .andThen(GridSyncDetector(syncConfig, config.id, config.syncStatusItem))
+      .andThen(
+        GridSyncDetector(
+          syncConfig,
+          config.id,
+          config.syncStatusItem,
+          config.syncNotification
+        )
+      )
       .andThen(
         GridRelaySyncDetector(
           syncConfig,
           config.id,
-          config.syncRelayStatusItem
+          config.syncRelayStatusItem,
+          config.syncRelayNotification
         )
       )
       .andThen(

--- a/src/main/scala/calespiga/processor/grid/GridProcessor.scala
+++ b/src/main/scala/calespiga/processor/grid/GridProcessor.scala
@@ -19,6 +19,13 @@ object GridProcessor {
       .andThen(GridConnectionProcessor(config, manager))
       .andThen(GridSyncDetector(syncConfig, config.id, config.syncStatusItem))
       .andThen(
+        GridRelaySyncDetector(
+          syncConfig,
+          config.id,
+          config.syncRelayStatusItem
+        )
+      )
+      .andThen(
         GridOfflineDetector(
           offlineConfig,
           config.id,

--- a/src/main/scala/calespiga/processor/grid/GridRelaySyncDetector.scala
+++ b/src/main/scala/calespiga/processor/grid/GridRelaySyncDetector.scala
@@ -26,7 +26,8 @@ private object GridRelaySyncDetector {
   def apply(
       syncConfig: SyncDetectorConfig,
       id: String,
-      statusItem: String
+      statusItem: String,
+      messageOffline: String
   ): SyncDetector =
     SyncDetector(
       syncConfig,
@@ -36,6 +37,7 @@ private object GridRelaySyncDetector {
       getLastSyncing,
       setLastSyncing,
       statusItem,
-      isEventRelevant
+      isEventRelevant,
+      Some(messageOffline)
     )
 }

--- a/src/main/scala/calespiga/processor/grid/GridRelaySyncDetector.scala
+++ b/src/main/scala/calespiga/processor/grid/GridRelaySyncDetector.scala
@@ -6,14 +6,14 @@ import calespiga.processor.utils.SyncDetector
 import com.softwaremill.quicklens.*
 import java.time.Instant
 
-private object GridSyncDetector {
+private object GridRelaySyncDetector {
 
   private def field1ToCheck(state: State) = state.grid.lastCommandSent
-  private def field2ToCheck(state: State) = state.grid.statusConnection
+  private def field2ToCheck(state: State) = state.grid.statusRelay
 
-  private def getLastSyncing(state: State) = state.grid.lastSyncingConnection
+  private def getLastSyncing(state: State) = state.grid.lastSyncingRelay
   private def setLastSyncing(state: State, when: Option[Instant]) =
-    state.modify(_.grid.lastSyncingConnection).setTo(when)
+    state.modify(_.grid.lastSyncingRelay).setTo(when)
 
   private val isEventRelevant: Event.EventData => Boolean = {
     case Event.Grid.GridConnectionStatusReported(_) => true

--- a/src/main/scala/calespiga/processor/grid/GridSyncDetector.scala
+++ b/src/main/scala/calespiga/processor/grid/GridSyncDetector.scala
@@ -26,7 +26,8 @@ private object GridSyncDetector {
   def apply(
       syncConfig: SyncDetectorConfig,
       id: String,
-      statusItem: String
+      statusItem: String,
+      messageOffline: String
   ): SyncDetector =
     SyncDetector(
       syncConfig,
@@ -36,6 +37,7 @@ private object GridSyncDetector {
       getLastSyncing,
       setLastSyncing,
       statusItem,
-      isEventRelevant
+      isEventRelevant,
+      Some(messageOffline)
     )
 }

--- a/src/main/scala/calespiga/processor/utils/SyncDetector.scala
+++ b/src/main/scala/calespiga/processor/utils/SyncDetector.scala
@@ -6,8 +6,33 @@ import java.time.Instant
 import SyncDetector.CheckSyncResult
 import calespiga.processor.SingleProcessor
 
+/** Generic synchronization detector processor that can be used for any
+  * component by providing two fields to compare for sync status, functions to
+  * get and set the last syncing time in the state, and a function to determine
+  * if an event is relevant for checking sync. It handles scheduling the timeout
+  * for determining non-sync status and updating a UI item with the current sync
+  * status.
+  *
+  * The state does not keep the sync status directly, but instead indirectly via
+  * two fileds in the state and the last time they were detected as not in sync.
+  * This allows for more flexible logic to determine sync status and to keep
+  * track of how long the system has been out of sync.
+  *
+  * The trait allows to check the sync status on demand via the checkIfInSync
+  * method, which can be used by other processors (e.g. to determine if a device
+  * can be turned on depending on if the gid is connected or not).
+  */
+
 trait SyncDetector extends SingleProcessor {
 
+  /** Checks if the two fields are in sync and returns the sync status,
+    * including how long they have been out of sync if applicable. This can be
+    * used by other processors to determine if certain actions can be performed
+    * depending on the sync status.
+    *
+    * @param state
+    * @return
+    */
   def checkIfInSync(state: State): CheckSyncResult
 
 }
@@ -21,6 +46,37 @@ object SyncDetector {
   case object NotInSyncNow extends CheckSyncResult
   final case class NotInSync(since: Instant) extends CheckSyncResult
 
+  /** Creates a synchronization detector processor.
+    *
+    * @param config
+    *   Configuration for the sync detector, including timeout duration and text
+    *   to display for different sync statuses.
+    * @param id
+    *   Identifier for the component being monitored (used for scheduling and
+    *   feedback events).
+    * @param field1ToCheck
+    *   The first field to compare for determining sync status. This is
+    *   typically the last command sent to a device or the desired state.
+    * @param field2ToCheck
+    *   The second field to compare for determining sync status. This is
+    *   typically the last status received from a device or the actual state.
+    * @param getLastSyncing
+    *   Function to get the last time the system was detected as not in sync
+    *   from the state.
+    * @param setLastSyncing
+    *   Function to set the last time the system was detected as not in sync in
+    *   the state.
+    * @param statusItem
+    *   The UI item to update with the current sync status.
+    * @param isEventRelevant
+    *   Function to determine if an event is relevant for checking sync status.
+    *   Only relevant events will trigger a re-check of the sync status and
+    *   potential updates to the UI item.
+    * @param messageOffline
+    *   Optional message to display when the component goes not in sync. If not
+    *   provided, no notification is sent on offline.
+    * @return
+    */
   def apply[T](
       config: SyncDetectorConfig,
       id: String,
@@ -29,7 +85,8 @@ object SyncDetector {
       getLastSyncing: State => Option[Instant],
       setLastSyncing: (State, Option[Instant]) => State,
       statusItem: String,
-      isEventRelevant: Event.EventData => Boolean
+      isEventRelevant: Event.EventData => Boolean,
+      messageOffline: Option[String] = None
   ): SyncDetector =
     Impl(
       config,
@@ -39,7 +96,8 @@ object SyncDetector {
       getLastSyncing,
       setLastSyncing,
       statusItem,
-      isEventRelevant
+      isEventRelevant,
+      messageOffline
     )
 
   private final case class Impl[T](
@@ -50,8 +108,12 @@ object SyncDetector {
       getLastSyncing: State => Option[Instant],
       setLastSyncing: (State, Option[Instant]) => State,
       statusItem: String,
-      isEventRelevant: Event.EventData => Boolean
+      isEventRelevant: Event.EventData => Boolean,
+      messageOffline: Option[String]
   ) extends SyncDetector {
+
+    val idUiUpdate = id
+    val idNotification = id + "-notification"
 
     override def checkIfInSync(state: State): CheckSyncResult =
       if (field1ToCheck(state) == field2ToCheck(state))
@@ -75,8 +137,14 @@ object SyncDetector {
             case Some(value) =>
               val actions = Set(
                 Action.SetUIItemValue(statusItem, config.syncText),
-                Action.Cancel(id)
-              )
+                Action.Cancel(idUiUpdate)
+              ) ++ (messageOffline match {
+                case Some(message) =>
+                  Set(Action.Cancel(idNotification))
+                case None =>
+                  // do nothing as the action was not set
+                  Set.empty
+              })
               (setLastSyncing(state, None), actions)
             case None =>
               // do nothing as the actions were already set
@@ -93,7 +161,17 @@ object SyncDetector {
               Action.SetUIItemValue(statusItem, config.nonSyncText),
               config.timeoutDuration
             )
-          )
+          ) ++ (messageOffline match {
+            case Some(message) =>
+              Set(
+                Action.Delayed(
+                  idNotification,
+                  Action.SendNotification(id, message, None),
+                  config.timeoutDuration
+                )
+              )
+            case None => Set.empty
+          })
           (setLastSyncing(state, Some(timestamp)), actions)
 
     } else {

--- a/src/test/scala/calespiga/processor/ProcessorConfigHelper.scala
+++ b/src/test/scala/calespiga/processor/ProcessorConfigHelper.scala
@@ -133,7 +133,9 @@ object ProcessorConfigHelper {
     resendInterval = 20.seconds,
     tariffItem = "grid/tariff",
     onlineStatusItem = "grid/onlineStatus",
-    offlineNotification = "El dispositiu de control de la xarxa no respon"
+    offlineNotification = "El dispositiu de control de la xarxa no respon",
+    syncNotification = "El dispositiu de control de la xarxa no respon",
+    syncRelayNotification = "El dispositiu de control de la xarxa no respon"
   )
 
   val batteryConfig: BatteryConfig = BatteryConfig(

--- a/src/test/scala/calespiga/processor/ProcessorConfigHelper.scala
+++ b/src/test/scala/calespiga/processor/ProcessorConfigHelper.scala
@@ -128,6 +128,7 @@ object ProcessorConfigHelper {
     statusItem = "grid/status",
     manualSwitchItem = "grid/manualSwitch",
     syncStatusItem = "grid/syncStatus",
+    syncRelayStatusItem = "grid/syncRelayStatus",
     reasonItem = "grid/connectionReason",
     resendInterval = 20.seconds,
     tariffItem = "grid/tariff",

--- a/src/test/scala/calespiga/processor/grid/GridConnectionProcessorSuite.scala
+++ b/src/test/scala/calespiga/processor/grid/GridConnectionProcessorSuite.scala
@@ -62,7 +62,7 @@ class GridConnectionProcessorSuite extends FunSuite {
 
     val (newState, actions) = processor.process(state, event, now)
 
-    assertEquals(newState.grid.status, Some(GridSignal.Connected))
+    assertEquals(newState.grid.statusConnection, Some(GridSignal.Connected))
     assertEquals(
       actions,
       Set[Action](Action.SetUIItemValue(config.statusItem, "on"))
@@ -75,16 +75,32 @@ class GridConnectionProcessorSuite extends FunSuite {
   test("GridConnectionStatusReported with Disconnected sets status to off") {
     val stub = ManagerStub()
     val processor = GridConnectionProcessor(config, stub)
-    val state = State().modify(_.grid.status).setTo(Some(GridSignal.Connected))
+    val state =
+      State().modify(_.grid.statusConnection).setTo(Some(GridSignal.Connected))
     val event = Event.Grid.GridConnectionStatusReported(GridSignal.Disconnected)
 
     val (newState, actions) = processor.process(state, event, now)
 
-    assertEquals(newState.grid.status, Some(GridSignal.Disconnected))
+    assertEquals(newState.grid.statusConnection, Some(GridSignal.Disconnected))
     assertEquals(
       actions,
       Set[Action](Action.SetUIItemValue(config.statusItem, "off"))
     )
+  }
+
+  test("GridRelayStatusReported updates grid relay status and no actions") {
+    val stub = ManagerStub()
+    val processor = GridConnectionProcessor(config, stub)
+    val state = State()
+    val event = Event.Grid.GridRelayStatusReported(GridSignal.Connected)
+
+    val (newState, actions) = processor.process(state, event, now)
+
+    assertEquals(newState.grid.statusRelay, Some(GridSignal.Connected))
+    assertEquals(actions, Set.empty[Action])
+    // manager must not be involved for relay status reports
+    assertEquals(stub.requestCalls, Nil)
+    assertEquals(stub.releaseCalls, Nil)
   }
 
   // ── GridManualConnectionChanged ──────────────────────────────────────────────

--- a/src/test/scala/calespiga/processor/utils/SyncDetectorSuite.scala
+++ b/src/test/scala/calespiga/processor/utils/SyncDetectorSuite.scala
@@ -42,6 +42,19 @@ class SyncDetectorSuite extends FunSuite {
     isEventRelevant
   )
 
+  val message = "Component offline"
+  val detectorWithMsg = SyncDetector(
+    config,
+    id,
+    field1ToCheck,
+    field2ToCheck,
+    getLastSyncing,
+    setLastSyncing,
+    statusItem,
+    isEventRelevant,
+    Some(message)
+  )
+
   val dummyEvent = Event.Temperature.BatteryTemperatureMeasured(0.0)
 
   test(
@@ -126,5 +139,53 @@ class SyncDetectorSuite extends FunSuite {
     val (newState, actions) = detector.process(state, anotherEvent, now)
     assertEquals(newState, state)
     assertEquals(actions, Set.empty)
+  }
+
+  test(
+    "Not in sync with messageOffline: schedules delayed NON_SYNC and notification"
+  ) {
+    val state = State().copy(heater =
+      State.Heater(
+        status = Some(HeaterSignal.Power500),
+        lastCommandSent = Some(HeaterSignal.Power1000),
+        lastSyncing = None
+      )
+    )
+    val (newState, actions) = detectorWithMsg.process(state, dummyEvent, now)
+    assertEquals(newState.heater.lastSyncing, Some(now))
+    val expectedActions = Set(
+      Action.SetUIItemValue(statusItem, config.syncingText),
+      Action.Delayed(
+        id + SyncDetector.ID_SUFFIX,
+        Action.SetUIItemValue(statusItem, config.nonSyncText),
+        config.timeoutDuration
+      ),
+      Action.Delayed(
+        id + SyncDetector.ID_SUFFIX + "-notification",
+        Action.SendNotification(id + SyncDetector.ID_SUFFIX, message, None),
+        config.timeoutDuration
+      )
+    )
+    assertEquals(actions, expectedActions)
+  }
+
+  test(
+    "Already in sync with prior syncing time and messageOffline: clears lastSyncing and cancels notification"
+  ) {
+    val state = State().copy(heater =
+      State.Heater(
+        status = Some(HeaterSignal.Power500),
+        lastCommandSent = Some(HeaterSignal.Power500),
+        lastSyncing = Some(now)
+      )
+    )
+    val (newState, actions) = detectorWithMsg.process(state, dummyEvent, now)
+    assertEquals(newState.heater.lastSyncing, None)
+    val expectedActions = Set(
+      Action.SetUIItemValue(statusItem, config.syncText),
+      Action.Cancel(id + SyncDetector.ID_SUFFIX),
+      Action.Cancel(id + SyncDetector.ID_SUFFIX + "-notification")
+    )
+    assertEquals(actions, expectedActions)
   }
 }


### PR DESCRIPTION
This PR adds a new sync detector for the relay in the grid microcotroller. This gives more grnaularity when detecting if the grid is not in sync with the state, so it is known if it is due to a problem on the microcontroller (and thus the microcontroller is not activatin the relay), or becuase the grid is not available although the relay is in sync (for example on the event of a grid cut).

It is added also a notification on these cases, so in the event of a syncronization problem, the users know proactively.