### PR TITLE
[FEATURE] Feature flags disables sync notifications

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -173,6 +173,9 @@ processor {
         set-infrared-stove-enabled-item = "EstufaInfrarrojosEnabledSHS"
         grid-mqtt-topic = [${processor.grid.mqtt-topic-for-command}]
         set-grid-connection-enabled-item = "XarxaEnabledSHS"
+        heater-ui-notification = []
+        infrared-stove-ui-notification = []
+        grid-ui-notification = ["grid-processor-sync-detector", "grid-processor-sync-detector-relay"]
         car-charger-mqtt-topic = [${processor.car-charger.mqtt-topic-for-command}]
         set-car-charger-management-item = "CarChargerHabilitatsSHS"
     }

--- a/src/main/scala/calespiga/Main.scala
+++ b/src/main/scala/calespiga/Main.scala
@@ -112,6 +112,7 @@ object Main extends IOApp.Simple {
         inputTopicsManager.inputTopicsConversions
       )
       mqttBlacklist <- Ref.of[IO, Set[String]](Set.empty).toResource
+      uiBlacklist <- Ref.of[IO, Set[String]](Set.empty).toResource
       mqttActionToProducer = ActionToMqttProducer(mqttProducer, mqttBlacklist)
       openHabApiClient <- APIClient(
         appConfig.uiConfig.openHabConfig,
@@ -124,7 +125,8 @@ object Main extends IOApp.Simple {
       )
       userInterfaceManager <- UserInterfaceManager(
         openHabApiClient,
-        appConfig.uiConfig
+        appConfig.uiConfig,
+        uiBlacklist = uiBlacklist
       ).toResource
       feedbackQueue <- Queue.unbounded[IO, FeedbackEventData].toResource
       directExecutor = DirectExecutor(
@@ -145,7 +147,12 @@ object Main extends IOApp.Simple {
         )
       )
       zoneId = ZoneId.of(appConfig.system.timezone)
-      processor = StateProcessor(appConfig.processor, mqttBlacklist, zoneId)
+      processor = StateProcessor(
+        appConfig.processor,
+        mqttBlacklist,
+        uiBlacklist,
+        zoneId
+      )
       _ <- Endpoints(stateRef, healthStatusManager, appConfig.httpServerConfig)
       powerSource <- powerDeps(appConfig.powerProduction, zoneId)
       tariffSource = GridTariffSource(zoneId)

--- a/src/main/scala/calespiga/config/ApplicationConfig.scala
+++ b/src/main/scala/calespiga/config/ApplicationConfig.scala
@@ -197,6 +197,9 @@ final case class FeatureFlagsConfig(
     setInfraredStoveEnabledItem: String,
     gridMqttTopic: Set[String],
     setGridConnectionEnabledItem: String,
+    heaterUiNotification: Set[String],
+    infraredStoveUiNotification: Set[String],
+    gridUiNotification: Set[String],
     carChargerMqttTopic: Set[String],
     setCarChargerManagementItem: String
 ) derives ConfigReader

--- a/src/main/scala/calespiga/processor/FeatureFlagsProcessor.scala
+++ b/src/main/scala/calespiga/processor/FeatureFlagsProcessor.scala
@@ -15,6 +15,7 @@ object FeatureFlagsProcessor {
 
   private case class Impl(
       mqttBlacklist: Ref[IO, Set[String]],
+      uiBlacklist: Ref[IO, Set[String]],
       config: FeatureFlagsConfig
   ) extends EffectfulProcessor {
 
@@ -45,6 +46,23 @@ object FeatureFlagsProcessor {
                   config.carChargerMqttTopic
                 else Set.empty
               bl ++ heaterBl ++ stoveBl ++ gridBl ++ carChargerBl
+            }
+            .flatMap { _ =>
+              uiBlacklist.update { bl =>
+                val heaterBl =
+                  if (!state.featureFlags.heaterManagementEnabled)
+                    config.heaterUiNotification
+                  else Set.empty
+                val stoveBl =
+                  if (!state.featureFlags.infraredStoveEnabled)
+                    config.infraredStoveUiNotification
+                  else Set.empty
+                val gridBl =
+                  if (!state.featureFlags.gridConnectionEnabled)
+                    config.gridUiNotification
+                  else Set.empty
+                bl ++ heaterBl ++ stoveBl ++ gridBl
+              }
             }
             .as(
               (
@@ -133,6 +151,12 @@ object FeatureFlagsProcessor {
           }
           mqttBlacklist
             .update(modifier)
+            .flatMap(_ =>
+              uiBlacklist.update { bl =>
+                if (enable) bl -- config.gridUiNotification
+                else bl ++ config.gridUiNotification
+              }
+            )
             .as(
               (
                 state
@@ -154,6 +178,7 @@ object FeatureFlagsProcessor {
 
   def apply(
       mqttBlacklist: Ref[IO, Set[String]],
+      uiBlacklist: Ref[IO, Set[String]],
       config: FeatureFlagsConfig
-  ): EffectfulProcessor = Impl(mqttBlacklist, config)
+  ): EffectfulProcessor = Impl(mqttBlacklist, uiBlacklist, config)
 }

--- a/src/main/scala/calespiga/processor/StateProcessor.scala
+++ b/src/main/scala/calespiga/processor/StateProcessor.scala
@@ -50,6 +50,7 @@ object StateProcessor {
   private[processor] def allButPower(
       config: calespiga.config.ProcessorConfig,
       mqttBlacklist: Ref[IO, Set[String]],
+      uiBlacklist: Ref[IO, Set[String]],
       zoneId: ZoneId
   ): List[EffectfulProcessor] = {
     val gridManager = GridConnectionManager(config.grid)
@@ -89,17 +90,19 @@ object StateProcessor {
         config.offlineDetector,
         config.syncDetector
       ).toEffectful,
-      FeatureFlagsProcessor(mqttBlacklist, config.featureFlags)
+      FeatureFlagsProcessor(mqttBlacklist, uiBlacklist, config.featureFlags)
     )
   }
 
   def apply(
       config: calespiga.config.ProcessorConfig,
       mqttBlacklist: Ref[IO, Set[String]],
+      uiBlacklist: Ref[IO, Set[String]],
       zoneId: ZoneId
   ): StateProcessor = {
 
-    val allButPowerProcessors = allButPower(config, mqttBlacklist, zoneId)
+    val allButPowerProcessors =
+      allButPower(config, mqttBlacklist, uiBlacklist, zoneId)
 
     val power = PowerProcessor(
       config.power,

--- a/src/main/scala/calespiga/processor/grid/GridRelaySyncDetector.scala
+++ b/src/main/scala/calespiga/processor/grid/GridRelaySyncDetector.scala
@@ -8,6 +8,8 @@ import java.time.Instant
 
 private object GridRelaySyncDetector {
 
+  private val ID_MODIFIER = "relay"
+
   private def field1ToCheck(state: State) = state.grid.lastCommandSent
   private def field2ToCheck(state: State) = state.grid.statusRelay
 
@@ -31,7 +33,7 @@ private object GridRelaySyncDetector {
   ): SyncDetector =
     SyncDetector(
       syncConfig,
-      id,
+      s"$id-$ID_MODIFIER",
       field1ToCheck,
       field2ToCheck,
       getLastSyncing,

--- a/src/main/scala/calespiga/ui/UserInterfaceManager.scala
+++ b/src/main/scala/calespiga/ui/UserInterfaceManager.scala
@@ -55,7 +55,8 @@ object UserInterfaceManager {
       openhabApiClient: APIClient,
       itemsConverter: OpenHabItemsConverter,
       uiConfig: UIConfig,
-      sentMessages: Ref[IO, Map[String, Instant]]
+      sentMessages: Ref[IO, Map[String, Instant]],
+      uiBlacklist: Ref[IO, Set[String]]
   ) extends UserInterfaceManager {
 
     override def updateUIItem(item: String, value: String): IO[Unit] =
@@ -67,27 +68,35 @@ object UserInterfaceManager {
         repeatInterval: Option[FiniteDuration]
     ): IO[Unit] =
       for {
-        now <- IO.realTimeInstant
-        repeatIntervalValue = repeatInterval.getOrElse(
-          uiConfig.defaultRepeatInterval
-        )
-        shouldSend <- sentMessages.modify { sent =>
-          sent.get(id) match {
-            case None =>
-              (sent + (id -> now), true)
-            case Some(lastSent) =>
-              if (
-                now.isAfter(lastSent.plusMillis(repeatIntervalValue.toMillis))
-              ) {
-                (sent + (id -> now), true)
-              } else {
-                (sent, false)
+        blocked <- uiBlacklist.get.map(_.contains(id))
+        _ <-
+          if (blocked) IO.unit
+          else
+            for {
+              now <- IO.realTimeInstant
+              repeatIntervalValue = repeatInterval.getOrElse(
+                uiConfig.defaultRepeatInterval
+              )
+              shouldSend <- sentMessages.modify { sent =>
+                sent.get(id) match {
+                  case None =>
+                    (sent + (id -> now), true)
+                  case Some(lastSent) =>
+                    if (
+                      now.isAfter(
+                        lastSent.plusMillis(repeatIntervalValue.toMillis)
+                      )
+                    ) {
+                      (sent + (id -> now), true)
+                    } else {
+                      (sent, false)
+                    }
+                }
               }
-          }
-        }
-        _ <- openhabApiClient
-          .changeItem(uiConfig.notificationsItem, message)
-          .whenA(shouldSend)
+              _ <- openhabApiClient
+                .changeItem(uiConfig.notificationsItem, message)
+                .whenA(shouldSend)
+            } yield ()
       } yield ()
 
     override def userInputEventsStream
@@ -134,10 +143,17 @@ object UserInterfaceManager {
   def apply(
       openhabApiClient: APIClient,
       uiConfig: UIConfig,
-      itemsConverter: OpenHabItemsConverter = openHabItems
+      itemsConverter: OpenHabItemsConverter = openHabItems,
+      uiBlacklist: Ref[IO, Set[String]]
   ): IO[UserInterfaceManager] =
     Ref.of[IO, Map[String, Instant]](Map.empty).map { sentMessages =>
-      Impl(openhabApiClient, itemsConverter, uiConfig, sentMessages)
+      Impl(
+        openhabApiClient,
+        itemsConverter,
+        uiConfig,
+        sentMessages,
+        uiBlacklist
+      )
     }
 
 }

--- a/src/test/scala/calespiga/processor/FeatureFlagsProcessorSuite.scala
+++ b/src/test/scala/calespiga/processor/FeatureFlagsProcessorSuite.scala
@@ -19,7 +19,12 @@ class FeatureFlagsProcessorSuite extends CatsEffectSuite {
   ) {
     for {
       blacklistRef <- Ref.of[IO, Set[String]](Set.empty)
-      processor = FeatureFlagsProcessor(blacklistRef, dummyConfig)
+      uiBlacklistRef <- Ref.of[IO, Set[String]](Set.empty)
+      processor = FeatureFlagsProcessor(
+        blacklistRef,
+        uiBlacklistRef,
+        dummyConfig
+      )
       state = State()
         .modify(_.featureFlags.heaterManagementEnabled)
         .setTo(false)
@@ -29,6 +34,7 @@ class FeatureFlagsProcessorSuite extends CatsEffectSuite {
         .setTo(false)
       (_, actions) <- processor.process(state, startupEvent, now)
       blacklist <- blacklistRef.get
+      uiBlacklist <- uiBlacklistRef.get
     } yield {
       dummyConfig.heaterMqttTopic.foreach { topic =>
         assert(blacklist.contains(topic))
@@ -38,6 +44,9 @@ class FeatureFlagsProcessorSuite extends CatsEffectSuite {
       }
       dummyConfig.carChargerMqttTopic.foreach { topic =>
         assert(blacklist.contains(topic))
+      }
+      dummyConfig.gridUiNotification.foreach { id =>
+        assert(uiBlacklist.contains(id))
       }
       assertEquals(
         actions,
@@ -66,7 +75,12 @@ class FeatureFlagsProcessorSuite extends CatsEffectSuite {
   test("StartupEvent with feature flags true does not add blacklist items") {
     for {
       blacklistRef <- Ref.of[IO, Set[String]](Set.empty)
-      processor = FeatureFlagsProcessor(blacklistRef, dummyConfig)
+      uiBlacklistRef <- Ref.of[IO, Set[String]](Set.empty)
+      processor = FeatureFlagsProcessor(
+        blacklistRef,
+        uiBlacklistRef,
+        dummyConfig
+      )
       state = State()
         .modify(_.featureFlags.heaterManagementEnabled)
         .setTo(true)
@@ -78,8 +92,10 @@ class FeatureFlagsProcessorSuite extends CatsEffectSuite {
         .setTo(true)
       (_, actions) <- processor.process(state, startupEvent, now)
       blacklist <- blacklistRef.get
+      uiBlacklist <- uiBlacklistRef.get
     } yield {
       assertEquals(blacklist, Set.empty)
+      assertEquals(uiBlacklist, Set.empty)
       assertEquals(
         actions,
         Set[Action](
@@ -109,7 +125,12 @@ class FeatureFlagsProcessorSuite extends CatsEffectSuite {
   ) {
     for {
       blacklistRef <- Ref.of[IO, Set[String]](Set.empty)
-      processor = FeatureFlagsProcessor(blacklistRef, dummyConfig)
+      uiBlacklistRef <- Ref.of[IO, Set[String]](Set.empty)
+      processor = FeatureFlagsProcessor(
+        blacklistRef,
+        uiBlacklistRef,
+        dummyConfig
+      )
       state = State().modify(_.featureFlags.heaterManagementEnabled).setTo(true)
       (newState, _) <- processor.process(
         state,
@@ -132,7 +153,12 @@ class FeatureFlagsProcessorSuite extends CatsEffectSuite {
       blacklistRef <- Ref.of[IO, Set[String]](
         dummyConfig.heaterMqttTopic
       )
-      processor = FeatureFlagsProcessor(blacklistRef, dummyConfig)
+      uiBlacklistRef <- Ref.of[IO, Set[String]](Set.empty)
+      processor = FeatureFlagsProcessor(
+        blacklistRef,
+        uiBlacklistRef,
+        dummyConfig
+      )
       state = State()
         .modify(_.featureFlags.heaterManagementEnabled)
         .setTo(false)
@@ -155,7 +181,12 @@ class FeatureFlagsProcessorSuite extends CatsEffectSuite {
   ) {
     for {
       blacklistRef <- Ref.of[IO, Set[String]](Set.empty)
-      processor = FeatureFlagsProcessor(blacklistRef, dummyConfig)
+      uiBlacklistRef <- Ref.of[IO, Set[String]](Set.empty)
+      processor = FeatureFlagsProcessor(
+        blacklistRef,
+        uiBlacklistRef,
+        dummyConfig
+      )
       state = State()
         .modify(_.featureFlags.infraredStoveEnabled)
         .setTo(true)
@@ -180,7 +211,12 @@ class FeatureFlagsProcessorSuite extends CatsEffectSuite {
       blacklistRef <- Ref.of[IO, Set[String]](
         dummyConfig.infraredStoveMqttTopic
       )
-      processor = FeatureFlagsProcessor(blacklistRef, dummyConfig)
+      uiBlacklistRef <- Ref.of[IO, Set[String]](Set.empty)
+      processor = FeatureFlagsProcessor(
+        blacklistRef,
+        uiBlacklistRef,
+        dummyConfig
+      )
       state = State()
         .modify(_.featureFlags.infraredStoveEnabled)
         .setTo(false)
@@ -203,7 +239,12 @@ class FeatureFlagsProcessorSuite extends CatsEffectSuite {
   ) {
     for {
       blacklistRef <- Ref.of[IO, Set[String]](Set.empty)
-      processor = FeatureFlagsProcessor(blacklistRef, dummyConfig)
+      uiBlacklistRef <- Ref.of[IO, Set[String]](Set.empty)
+      processor = FeatureFlagsProcessor(
+        blacklistRef,
+        uiBlacklistRef,
+        dummyConfig
+      )
       state = State()
         .modify(_.featureFlags.gridConnectionEnabled)
         .setTo(true)
@@ -213,9 +254,13 @@ class FeatureFlagsProcessorSuite extends CatsEffectSuite {
         now
       )
       blacklist <- blacklistRef.get
+      uiBlacklist <- uiBlacklistRef.get
     } yield {
       dummyConfig.gridMqttTopic.foreach { topic =>
         assert(blacklist.contains(topic))
+      }
+      dummyConfig.gridUiNotification.foreach { id =>
+        assert(uiBlacklist.contains(id))
       }
       assertEquals(newState.featureFlags.gridConnectionEnabled, false)
     }
@@ -228,7 +273,12 @@ class FeatureFlagsProcessorSuite extends CatsEffectSuite {
       blacklistRef <- Ref.of[IO, Set[String]](
         dummyConfig.gridMqttTopic
       )
-      processor = FeatureFlagsProcessor(blacklistRef, dummyConfig)
+      uiBlacklistRef <- Ref.of[IO, Set[String]](dummyConfig.gridUiNotification)
+      processor = FeatureFlagsProcessor(
+        blacklistRef,
+        uiBlacklistRef,
+        dummyConfig
+      )
       state = State()
         .modify(_.featureFlags.gridConnectionEnabled)
         .setTo(false)
@@ -238,9 +288,13 @@ class FeatureFlagsProcessorSuite extends CatsEffectSuite {
         now
       )
       blacklist <- blacklistRef.get
+      uiBlacklist <- uiBlacklistRef.get
     } yield {
       dummyConfig.gridMqttTopic.foreach { topic =>
         assert(!blacklist.contains(topic))
+      }
+      dummyConfig.gridUiNotification.foreach { id =>
+        assert(!uiBlacklist.contains(id))
       }
       assertEquals(newState.featureFlags.gridConnectionEnabled, true)
     }

--- a/src/test/scala/calespiga/processor/ProcessorConfigHelper.scala
+++ b/src/test/scala/calespiga/processor/ProcessorConfigHelper.scala
@@ -98,6 +98,9 @@ object ProcessorConfigHelper {
     setInfraredStoveEnabledItem = "featureFlags/setInfraredStoveEnabled",
     gridMqttTopic = Set("grid/topic1", "grid/topic2"),
     setGridConnectionEnabledItem = "featureFlags/setGridConnectionEnabled",
+    heaterUiNotification = Set.empty,
+    infraredStoveUiNotification = Set.empty,
+    gridUiNotification = Set("grid-processor-sync-detector"),
     carChargerMqttTopic = Set("cotxe/carrega/set"),
     setCarChargerManagementItem = "featureFlags/setCarChargerManagement"
   )

--- a/src/test/scala/calespiga/processor/StateProcessorSuite.scala
+++ b/src/test/scala/calespiga/processor/StateProcessorSuite.scala
@@ -70,6 +70,8 @@ class StateProcessorSuite extends CatsEffectSuite {
         .allButPower(
           config = ProcessorConfigHelper.processorConfig,
           mqttBlacklist = mqttBlacklist,
+          uiBlacklist =
+            mqttBlacklist, // uiBlacklist is not used in this test, we can pass the same Ref
           zoneId = ZoneId.systemDefault()
         )
         .flatMap(_.dynamicPowerConsumer)

--- a/src/test/scala/calespiga/ui/UserInterfaceManagerSuite.scala
+++ b/src/test/scala/calespiga/ui/UserInterfaceManagerSuite.scala
@@ -31,9 +31,11 @@ class UserInterfaceManagerSuite extends CatsEffectSuite {
         changeItemStub =
           (item: String, value: String) => called.set(Some((item, value)))
       )
+      uiBlack <- IO.ref[Set[String]](Set.empty)
       sut <- UserInterfaceManager(
         apiClient,
-        uiConfig
+        uiConfig,
+        uiBlacklist = uiBlack
       )
       _ <- sut.sendNotification(notificationId, message, None)
       calledValue <- called.get
@@ -59,9 +61,11 @@ class UserInterfaceManagerSuite extends CatsEffectSuite {
       apiClient = ApiClientStub(
         changeItemStub = (_: String, _: String) => called.update(_ + 1)
       )
+      uiBlack <- IO.ref[Set[String]](Set.empty)
       sut <- UserInterfaceManager(
         apiClient,
-        uiConfig
+        uiConfig,
+        uiBlacklist = uiBlack
       )
       _ <- sut.sendNotification(notificationId, message, Some(repeatInterval))
       calledValue1 <- called.get
@@ -100,9 +104,11 @@ class UserInterfaceManagerSuite extends CatsEffectSuite {
       apiClient = ApiClientStub(
         changeItemStub = (_: String, _: String) => called.update(_ + 1)
       )
+      uiBlack <- IO.ref[Set[String]](Set.empty)
       sut <- UserInterfaceManager(
         apiClient,
-        uiConfig
+        uiConfig,
+        uiBlacklist = uiBlack
       )
       _ <- sut.sendNotification(notificationId, message, Some(repeatInterval))
       calledValue1 <- called.get
@@ -144,9 +150,11 @@ class UserInterfaceManagerSuite extends CatsEffectSuite {
       apiClient = ApiClientStub(
         changeItemStub = (_: String, _: String) => called.update(_ + 1)
       )
+      uiBlack <- IO.ref[Set[String]](Set.empty)
       sut <- UserInterfaceManager(
         apiClient,
-        uiConfig
+        uiConfig,
+        uiBlacklist = uiBlack
       )
       _ <- sut.sendNotification(notificationId, message, None)
       calledValue1 <- called.get
@@ -184,7 +192,8 @@ class UserInterfaceManagerSuite extends CatsEffectSuite {
         itemChangesStub =
           _ => Stream.eval(called.set(true)).flatMap(_ => Stream.empty)
       )
-      sut <- UserInterfaceManager(apiClient, uiConfig)
+      uiBlack <- IO.ref[Set[String]](Set.empty)
+      sut <- UserInterfaceManager(apiClient, uiConfig, uiBlacklist = uiBlack)
       _ <- sut.userInputEventsStream.compile.drain
       calledValue <- called.get
     } yield {
@@ -199,7 +208,8 @@ class UserInterfaceManagerSuite extends CatsEffectSuite {
       itemChangesStub = _ => Stream(Left(error))
     )
     for {
-      sut <- UserInterfaceManager(apiClient, uiConfig)
+      uiBlack <- IO.ref[Set[String]](Set.empty)
+      sut <- UserInterfaceManager(apiClient, uiConfig, uiBlacklist = uiBlack)
       last <- sut.userInputEventsStream.compile.last
     } yield {
       assertEquals(
@@ -219,7 +229,8 @@ class UserInterfaceManagerSuite extends CatsEffectSuite {
     )
     val itemsConverter: UserInterfaceManager.OpenHabItemsConverter = Map()
     for {
-      sut <- UserInterfaceManager(apiClient, uiConfig, itemsConverter)
+      uiBlack <- IO.ref[Set[String]](Set.empty)
+      sut <- UserInterfaceManager(apiClient, uiConfig, itemsConverter, uiBlack)
       last <- sut.userInputEventsStream.compile.last
     } yield {
       last match {
@@ -243,7 +254,8 @@ class UserInterfaceManagerSuite extends CatsEffectSuite {
     val itemsConverter: UserInterfaceManager.OpenHabItemsConverter =
       Map("TestItem" -> (_ => Left(error)))
     for {
-      sut <- UserInterfaceManager(apiClient, uiConfig, itemsConverter)
+      uiBlack <- IO.ref[Set[String]](Set.empty)
+      sut <- UserInterfaceManager(apiClient, uiConfig, itemsConverter, uiBlack)
       last <- sut.userInputEventsStream.compile.last
     } yield {
       assertEquals(
@@ -266,7 +278,8 @@ class UserInterfaceManagerSuite extends CatsEffectSuite {
     val itemsConverter: UserInterfaceManager.OpenHabItemsConverter =
       Map("TestItem" -> (_ => Right(resultEventData)))
     for {
-      sut <- UserInterfaceManager(apiClient, uiConfig, itemsConverter)
+      uiBlack <- IO.ref[Set[String]](Set.empty)
+      sut <- UserInterfaceManager(apiClient, uiConfig, itemsConverter, uiBlack)
       last <- sut.userInputEventsStream.compile.last
     } yield {
       last match {
@@ -279,6 +292,31 @@ class UserInterfaceManagerSuite extends CatsEffectSuite {
           () // Test passed
         case _ => fail("The event was not propagated")
       }
+    }
+  }
+
+  test(
+    "sendNotification should NOT call the APIClient when id is blacklisted"
+  ) {
+    val notificationId = "BlockedNotification"
+    val message = "Should not be sent"
+
+    for {
+      called <- IO.ref[Option[(String, String)]](None)
+      apiClient = ApiClientStub(
+        changeItemStub =
+          (item: String, value: String) => called.set(Some((item, value)))
+      )
+      uiBlack <- IO.ref[Set[String]](Set(notificationId))
+      sut <- UserInterfaceManager(
+        apiClient,
+        uiConfig,
+        uiBlacklist = uiBlack
+      )
+      _ <- sut.sendNotification(notificationId, message, None)
+      calledValue <- called.get
+    } yield {
+      assertEquals(calledValue, None)
     }
   }
 


### PR DESCRIPTION
This PR adds a the ability to disable certain notifications on a Feature Flag disabled. It may become handy when adding sync detectors and managing the rollout, as the sync will not be possible most of the time if the SHS is not enabled.