### PR TITLE
[FEATURE] Car charger automatic fv mode

### DIFF
--- a/oh/items/smart-home-state.items
+++ b/oh/items/smart-home-state.items
@@ -63,6 +63,7 @@ String PotenciaEstatLecturesSHS "Estat lectures FV"
 
 Number CalentadorPrioritatConsumSHS "Calentador"
 Number EstufaInfrarrojosPrioritatConsumSHS "Est. Infrarrojos"
+Number CarChargerPrioritatConsumSHS "Carregador VE"
 
 /*
 ----------------------

--- a/oh/sitemaps/shs.sitemap
+++ b/oh/sitemaps/shs.sitemap
@@ -104,7 +104,7 @@ sitemap shs label="Ca l'espiga SHS" {
     Text item=CarChargerTitle label="Vehicle Elèctric" icon="electric_car"
     {
         Frame label="Carregador vehicle" {
-            Selection item=CarChargerSetSHS icon="switch" mappings=["off"="Off","on"="On","automatic"="Automàtic"]
+            Selection item=CarChargerSetSHS icon="switch" mappings=["off"="Off","on"="On","automatic_fv"="Automàtic FV"]
             Text item=CarChargerStatusSHS icon="car" label="Estat: [%s]"
             Text item=CarChargerSincronitzacioSHS icon="time" label="Sincronitzacio [%s]"
             Text item=CarChargerMicroControladorEstatSHS icon="network" label="Estat microcontrolador: [%s]"

--- a/oh/sitemaps/shs.sitemap
+++ b/oh/sitemaps/shs.sitemap
@@ -72,8 +72,9 @@ sitemap shs label="Ca l'espiga SHS" {
             Text item=PotenciaDinamicaFVSHS icon="power" label="Potència dinàmica FV: [%.0f W]"
         }
         Frame label="Dispositius" {
-            Setpoint item=CalentadorPrioritatConsumSHS icon="heater_display" label="Prioritat calentador [%d]" minValue=1 maxValue=2 step=1
-            Setpoint item=EstufaInfrarrojosPrioritatConsumSHS icon="heater_display" label="Prioritat estufa infrarrojos [%d]" minValue=1 maxValue=2 step=1
+            Setpoint item=CalentadorPrioritatConsumSHS icon="heater_display" label="Prioritat calentador [%d]" minValue=1 maxValue=3 step=1
+            Setpoint item=EstufaInfrarrojosPrioritatConsumSHS icon="heater_display" label="Prioritat estufa infrarrojos [%d]" minValue=1 maxValue=3 step=1
+            Setpoint item=CarChargerPrioritatConsumSHS icon="electric_car" label="Prioritat carregador VE [%d]" minValue=1 maxValue=3 step=1
         }
 
     }

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -218,5 +218,8 @@ processor {
         resend-interval = 20 seconds
         last-command-item = "CarChargerSetSHS"
         id = "car-charger-processor"
+        sync-timeout-for-dynamic-power = 1 minute
+        dynamic-consumer-code = "CarChargerPrioritatConsumSHS"
+        charger-power-watts = 2100.0
     }
 }

--- a/src/main/scala/calespiga/config/ApplicationConfig.scala
+++ b/src/main/scala/calespiga/config/ApplicationConfig.scala
@@ -84,7 +84,10 @@ final case class CarChargerConfig(
     mqttTopicForCommand: String,
     resendInterval: FiniteDuration,
     lastCommandItem: String,
-    id: String
+    id: String,
+    syncTimeoutForDynamicPower: FiniteDuration,
+    dynamicConsumerCode: String,
+    chargerPowerWatts: Float
 ) derives ConfigReader
 
 final case class PowerProcessorConfig(

--- a/src/main/scala/calespiga/model/CarChargerSignal.scala
+++ b/src/main/scala/calespiga/model/CarChargerSignal.scala
@@ -38,7 +38,7 @@ object CarChargerSignal {
   sealed trait UserCommand
   case object TurnOff extends UserCommand
   case object TurnOn extends UserCommand
-  case object SetAutomatic extends UserCommand
+  case object SetAutomaticFV extends UserCommand
 
   implicit val userCommandEncoder: Encoder[UserCommand] = Encoder.instance {
     c => Json.fromString(userCommandToString(c))
@@ -50,16 +50,16 @@ object CarChargerSignal {
     }
 
   def userCommandToString(cmd: UserCommand): String = cmd match
-    case TurnOff      => "off"
-    case TurnOn       => "on"
-    case SetAutomatic => "automatic"
+    case TurnOff        => "off"
+    case TurnOn         => "on"
+    case SetAutomaticFV => "automatic_fv"
 
   def userCommandFromString(str: String): Either[String, UserCommand] =
     str.toLowerCase match
-      case "off"       => Right(TurnOff)
-      case "on"        => Right(TurnOn)
-      case "automatic" => Right(SetAutomatic)
-      case other       => Left(s"Invalid CarChargerSignal.UserCommand: $other")
+      case "off"          => Right(TurnOff)
+      case "on"           => Right(TurnOn)
+      case "automatic_fv" => Right(SetAutomaticFV)
+      case other => Left(s"Invalid CarChargerSignal.UserCommand: $other")
 
   given Schema[UserCommand] = Schema.string
 }

--- a/src/main/scala/calespiga/processor/carCharger/Actions.scala
+++ b/src/main/scala/calespiga/processor/carCharger/Actions.scala
@@ -1,0 +1,19 @@
+package calespiga.processor.carCharger
+
+import calespiga.config.CarChargerConfig
+import calespiga.processor.utils.CommandActions
+import calespiga.model.CarChargerSignal
+
+object Actions {
+
+  def apply(
+      config: CarChargerConfig
+  ): CommandActions[CarChargerSignal.ControllerState] =
+    CommandActions[CarChargerSignal.ControllerState](
+      mqttTopic = config.mqttTopicForCommand,
+      id = config.id,
+      resendInterval = config.resendInterval,
+      commandToMessage = CarChargerSignal.controllerStateToString
+    )
+
+}

--- a/src/main/scala/calespiga/processor/carCharger/CarChargerDynamicPowerConsumer.scala
+++ b/src/main/scala/calespiga/processor/carCharger/CarChargerDynamicPowerConsumer.scala
@@ -1,0 +1,96 @@
+package calespiga.processor.carCharger
+
+import calespiga.processor.power.dynamic.DynamicPowerConsumer
+import calespiga.processor.power.dynamic.DynamicPowerConsumer.DynamicPowerResult
+import calespiga.model.State
+import calespiga.model.CarChargerSignal.SetAutomaticFV
+import calespiga.model.CarChargerSignal
+import calespiga.processor.power.dynamic.Power
+import com.softwaremill.quicklens.*
+import calespiga.config.CarChargerConfig
+import calespiga.processor.utils.SyncDetector
+import calespiga.model.CarChargerChargingStatus
+import java.time.Instant
+
+object CarChargerDynamicPowerConsumer {
+
+  private case class Impl(
+      config: CarChargerConfig,
+      carChargerSyncDetector: SyncDetector
+  ) extends DynamicPowerConsumer {
+
+    private val actions = Actions(config)
+
+    override def uniqueCode: String = config.dynamicConsumerCode
+
+    override def currentlyUsedDynamicPower(state: State, now: Instant): Power =
+      if (state.carCharger.lastCommandReceived.contains(SetAutomaticFV)) {
+        carChargerSyncDetector.checkIfInSync(state) match
+          case calespiga.processor.utils.SyncDetector.NotInSync(since)
+              if now.isAfter(
+                since.plusMillis(config.syncTimeoutForDynamicPower.toMillis)
+              ) =>
+            Power.zero
+          case _ =>
+            state.carCharger.switchStatus match
+              case Some(CarChargerSignal.On) =>
+                state.carCharger.currentPowerWatts
+                  .map(p => Power.ofFv(p))
+                  .getOrElse(Power.ofFv(config.chargerPowerWatts))
+              case _ => Power.zero
+      } else {
+        Power.zero
+      }
+
+    override def usePower(
+        state: State,
+        powerToUse: Power,
+        now: Instant
+    ): DynamicPowerResult =
+      if (!state.carCharger.lastCommandReceived.contains(SetAutomaticFV)) {
+        // car charger is not in automatic mode, do not use dynamic power
+        DynamicPowerResult(state, Set.empty, Power.zero)
+      } else {
+        val desiredControllerState =
+          carChargerSyncDetector.checkIfInSync(state) match
+            case calespiga.processor.utils.SyncDetector.NotInSync(since)
+                if now.isAfter(
+                  since.plusMillis(config.syncTimeoutForDynamicPower.toMillis)
+                ) =>
+              CarChargerSignal.Off
+            case _ =>
+              if (powerToUse.fv >= config.chargerPowerWatts) CarChargerSignal.On
+              else CarChargerSignal.Off
+
+        val newState = state
+          .modify(_.carCharger.lastCommandSent)
+          .setTo(Some(desiredControllerState))
+
+        val powerUsed =
+          desiredControllerState match
+            case CarChargerSignal.On =>
+              // if the charger reports it's actually charging, prefer the measured current power
+              state.carCharger.chargingStatus match
+                case Some(CarChargerChargingStatus.Charging) =>
+                  state.carCharger.currentPowerWatts
+                    .map(p => Power.ofFv(p))
+                    .getOrElse(Power.ofFv(config.chargerPowerWatts))
+                case _ => Power.ofFv(config.chargerPowerWatts)
+            case _ => Power.zero
+
+        DynamicPowerResult(
+          newState,
+          actions.commandActionWithResend(desiredControllerState),
+          powerUsed
+        )
+      }
+
+  }
+
+  def apply(
+      config: CarChargerConfig,
+      carChargerSyncDetector: SyncDetector
+  ): DynamicPowerConsumer =
+    Impl(config, carChargerSyncDetector)
+
+}

--- a/src/main/scala/calespiga/processor/carCharger/CarChargerPowerProcessor.scala
+++ b/src/main/scala/calespiga/processor/carCharger/CarChargerPowerProcessor.scala
@@ -3,7 +3,6 @@ package calespiga.processor.carCharger
 import calespiga.config.CarChargerConfig
 import calespiga.model.{State, Action, Event}
 import calespiga.processor.SingleProcessor
-import calespiga.processor.utils.CommandActions
 import com.softwaremill.quicklens.*
 import java.time.Instant
 
@@ -12,13 +11,7 @@ private[carCharger] object CarChargerPowerProcessor {
   private final case class Impl(config: CarChargerConfig)
       extends SingleProcessor {
 
-    private val actions =
-      CommandActions[calespiga.model.CarChargerSignal.ControllerState](
-        config.mqttTopicForCommand,
-        config.id,
-        config.resendInterval,
-        calespiga.model.CarChargerSignal.controllerStateToString
-      )
+    private val actions = Actions(config)
 
     private def getDefaultCommandToSend(
         status: calespiga.model.CarChargerSignal.UserCommand

--- a/src/main/scala/calespiga/processor/carCharger/CarChargerPowerProcessor.scala
+++ b/src/main/scala/calespiga/processor/carCharger/CarChargerPowerProcessor.scala
@@ -28,7 +28,7 @@ private[carCharger] object CarChargerPowerProcessor {
           calespiga.model.CarChargerSignal.Off
         case calespiga.model.CarChargerSignal.TurnOn =>
           calespiga.model.CarChargerSignal.On
-        case calespiga.model.CarChargerSignal.SetAutomatic =>
+        case calespiga.model.CarChargerSignal.SetAutomaticFV =>
           calespiga.model.CarChargerSignal.Off
 
     override def process(

--- a/src/main/scala/calespiga/processor/carCharger/CarChargerProcessor.scala
+++ b/src/main/scala/calespiga/processor/carCharger/CarChargerProcessor.scala
@@ -14,6 +14,9 @@ object CarChargerProcessor {
       offlineDetectorConfig: OfflineDetectorConfig,
       syncConfig: calespiga.config.SyncDetectorConfig
   ): SingleProcessor =
+    val carChargerSyncDetector =
+      CarChargerSyncDetector(syncConfig, config.id, config.syncStatusItem)
+
     CarChargerOfflineDetector(offlineDetectorConfig, config)
       .andThen(
         CarChargerStatusProcessor(config)
@@ -22,7 +25,10 @@ object CarChargerProcessor {
         CarChargerPowerProcessor(config)
       )
       .andThen(
-        CarChargerSyncDetector(syncConfig, config.id, config.syncStatusItem)
+        carChargerSyncDetector
+      )
+      .withDynamicConsumer(
+        CarChargerDynamicPowerConsumer(config, carChargerSyncDetector)
       )
       .andThen(
         CarChargerEnergyProcessor(config, zone)

--- a/src/test/scala/calespiga/processor/ProcessorConfigHelper.scala
+++ b/src/test/scala/calespiga/processor/ProcessorConfigHelper.scala
@@ -162,7 +162,10 @@ object ProcessorConfigHelper {
     mqttTopicForCommand = "dummy/carcharger/command",
     resendInterval = 20.seconds,
     lastCommandItem = "carcharger/lastCommand",
-    id = "car-charger-processor"
+    id = "car-charger-processor",
+    syncTimeoutForDynamicPower = 50.seconds,
+    dynamicConsumerCode = "car-charger-consumer-code",
+    chargerPowerWatts = 2100f
   )
 
   val processorConfig: ProcessorConfig = ProcessorConfig(

--- a/src/test/scala/calespiga/processor/carCharger/CarChargerDynamicPowerConsumerSuite.scala
+++ b/src/test/scala/calespiga/processor/carCharger/CarChargerDynamicPowerConsumerSuite.scala
@@ -1,0 +1,267 @@
+package calespiga.processor.carCharger
+
+import munit.FunSuite
+import calespiga.model.{State, Action, CarChargerSignal}
+import calespiga.processor.power.dynamic.Power
+import com.softwaremill.quicklens.*
+import calespiga.processor.utils.SyncDetectorStub
+import java.time.Instant
+import calespiga.processor.ProcessorConfigHelper
+
+class CarChargerDynamicPowerConsumerSuite extends FunSuite {
+
+  private val dummyConfig = ProcessorConfigHelper.carCharger
+
+  private val now = Instant.parse("2024-01-15T10:00:00Z")
+  private val consumer =
+    CarChargerDynamicPowerConsumer(dummyConfig, SyncDetectorStub())
+
+  private def stateWithCarCharger(
+      switchStatus: Option[CarChargerSignal.ControllerState] = None,
+      lastCommandSent: Option[CarChargerSignal.ControllerState] = None,
+      lastCommandReceived: Option[CarChargerSignal.UserCommand] = None,
+      currentPowerWatts: Option[Float] = None
+  ): State =
+    State()
+      .modify(_.carCharger)
+      .setTo(
+        State.CarCharger(
+          switchStatus = switchStatus,
+          lastCommandSent = lastCommandSent,
+          lastCommandReceived = lastCommandReceived,
+          lastChange = None,
+          lastSyncing = None,
+          currentPowerWatts = currentPowerWatts,
+          lastEnergyUpdate = None,
+          lastAccumulatedEnergyWh = None,
+          accumulatedAtDayStartWh = None,
+          online = None,
+          chargingStatus = None
+        )
+      )
+
+  // ============================================================
+  // currentlyUsedDynamicPower tests
+  // ============================================================
+
+  test("currentlyUsedDynamicPower: returns 0 when lastCommandReceived is OFF") {
+    val state = stateWithCarCharger(
+      switchStatus = Some(CarChargerSignal.On),
+      lastCommandReceived = Some(CarChargerSignal.TurnOff),
+      currentPowerWatts = Some(2500f)
+    )
+
+    val result = consumer.currentlyUsedDynamicPower(state, now)
+
+    assertEquals(result, Power.zero)
+  }
+
+  test(
+    "currentlyUsedDynamicPower: returns 0 when lastCommandReceived is None"
+  ) {
+    val state = stateWithCarCharger(
+      switchStatus = Some(CarChargerSignal.On),
+      currentPowerWatts = Some(2500f)
+    )
+
+    val result = consumer.currentlyUsedDynamicPower(state, now)
+
+    assertEquals(result, Power.zero)
+  }
+
+  test(
+    "currentlyUsedDynamicPower: returns 0 when automatic and switchStatus is Off"
+  ) {
+    val state = stateWithCarCharger(
+      switchStatus = Some(CarChargerSignal.Off),
+      lastCommandReceived = Some(CarChargerSignal.SetAutomaticFV),
+      currentPowerWatts = Some(2500f)
+    )
+
+    val result = consumer.currentlyUsedDynamicPower(state, now)
+
+    assertEquals(result, Power.zero)
+  }
+
+  test(
+    "currentlyUsedDynamicPower: returns config chargerPowerWatts when automatic and On and no current power"
+  ) {
+    val state = stateWithCarCharger(
+      switchStatus = Some(CarChargerSignal.On),
+      lastCommandReceived = Some(CarChargerSignal.SetAutomaticFV),
+      currentPowerWatts = None
+    )
+
+    val result = consumer.currentlyUsedDynamicPower(state, now)
+
+    assertEquals(result, Power.ofFv(dummyConfig.chargerPowerWatts))
+  }
+
+  test(
+    "currentlyUsedDynamicPower: returns currentPowerWatts when automatic and On and reading present"
+  ) {
+    val state = stateWithCarCharger(
+      switchStatus = Some(CarChargerSignal.On),
+      lastCommandReceived = Some(CarChargerSignal.SetAutomaticFV),
+      currentPowerWatts = Some(2500f)
+    )
+
+    val result = consumer.currentlyUsedDynamicPower(state, now)
+
+    assertEquals(result, Power.ofFv(2500f))
+  }
+
+  test(
+    "currentlyUsedDynamicPower: returns 0 when NotInSync beyond timeout interval"
+  ) {
+    val syncStartTime = now.minusSeconds(120)
+    val consumerWithSyncDetector = CarChargerDynamicPowerConsumer(
+      dummyConfig,
+      SyncDetectorStub(checkIfInSyncStub =
+        _ => calespiga.processor.utils.SyncDetector.NotInSync(syncStartTime)
+      )
+    )
+
+    val state = stateWithCarCharger(
+      switchStatus = Some(CarChargerSignal.On),
+      lastCommandReceived = Some(CarChargerSignal.SetAutomaticFV),
+      currentPowerWatts = Some(2500f)
+    )
+
+    val result = consumerWithSyncDetector.currentlyUsedDynamicPower(state, now)
+
+    assertEquals(result, Power.zero)
+  }
+
+  test("currentlyUsedDynamicPower: returns normal power when NotInSyncNow") {
+    val consumerWithSyncDetector = CarChargerDynamicPowerConsumer(
+      dummyConfig,
+      SyncDetectorStub(checkIfInSyncStub =
+        _ => calespiga.processor.utils.SyncDetector.NotInSyncNow
+      )
+    )
+
+    val state = stateWithCarCharger(
+      switchStatus = Some(CarChargerSignal.On),
+      lastCommandReceived = Some(CarChargerSignal.SetAutomaticFV),
+      currentPowerWatts = Some(2500f)
+    )
+
+    val result = consumerWithSyncDetector.currentlyUsedDynamicPower(state, now)
+
+    assertEquals(result, Power.ofFv(2500f))
+  }
+
+  // ============================================================
+  // usePower tests
+  // ============================================================
+
+  test(
+    "usePower: returns unchanged state, no actions, and zero power when not automatic"
+  ) {
+    val state = stateWithCarCharger(
+      lastCommandReceived = Some(CarChargerSignal.TurnOff)
+    )
+
+    val result = consumer.usePower(state, Power.ofFv(3000f), now)
+
+    assertEquals(result.state, state)
+    assertEquals(result.actions, Set.empty)
+    assertEquals(result.powerUsed, Power.zero)
+  }
+
+  test(
+    "usePower: sets On when automatic and available power >= chargerPowerWatts"
+  ) {
+    val state = stateWithCarCharger(
+      lastCommandReceived = Some(CarChargerSignal.SetAutomaticFV)
+    )
+
+    val result = consumer.usePower(state, Power.ofFv(2500f), now)
+
+    assertEquals(
+      result.state.carCharger.lastCommandSent,
+      Some(CarChargerSignal.On)
+    )
+    assertEquals(result.powerUsed, Power.ofFv(dummyConfig.chargerPowerWatts))
+
+    assert(result.actions.nonEmpty)
+    assertEquals(result.actions.size, 2)
+
+    val mqttAction = result.actions.collectFirst {
+      case a: Action.SendMqttStringMessage => a
+    }.get
+    assertEquals(mqttAction.topic, dummyConfig.mqttTopicForCommand)
+    assertEquals(mqttAction.message, "on")
+  }
+
+  test(
+    "usePower: sets Off when automatic and available power < chargerPowerWatts"
+  ) {
+    val state = stateWithCarCharger(
+      lastCommandReceived = Some(CarChargerSignal.SetAutomaticFV)
+    )
+
+    val result = consumer.usePower(state, Power.ofFv(1500f), now)
+
+    assertEquals(
+      result.state.carCharger.lastCommandSent,
+      Some(CarChargerSignal.Off)
+    )
+    assertEquals(result.powerUsed, Power.zero)
+
+    assert(result.actions.nonEmpty)
+    assertEquals(result.actions.size, 2)
+
+    val mqttAction = result.actions.collectFirst {
+      case a: Action.SendMqttStringMessage => a
+    }.get
+    assertEquals(mqttAction.message, "off")
+  }
+
+  test("usePower: sets On at boundary when power == chargerPowerWatts") {
+    val state = stateWithCarCharger(
+      lastCommandReceived = Some(CarChargerSignal.SetAutomaticFV)
+    )
+
+    val result =
+      consumer.usePower(state, Power.ofFv(dummyConfig.chargerPowerWatts), now)
+
+    assertEquals(
+      result.state.carCharger.lastCommandSent,
+      Some(CarChargerSignal.On)
+    )
+    assertEquals(result.powerUsed, Power.ofFv(dummyConfig.chargerPowerWatts))
+  }
+
+  test("usePower: sets Off and uses zero power when NotInSync beyond timeout") {
+    val syncStartTime = now.minusSeconds(120)
+    val consumerWithSyncDetector = CarChargerDynamicPowerConsumer(
+      dummyConfig,
+      SyncDetectorStub(checkIfInSyncStub =
+        _ => calespiga.processor.utils.SyncDetector.NotInSync(syncStartTime)
+      )
+    )
+
+    val state = stateWithCarCharger(
+      lastCommandReceived = Some(CarChargerSignal.SetAutomaticFV)
+    )
+
+    val result =
+      consumerWithSyncDetector.usePower(state, Power.ofFv(3000f), now)
+
+    assertEquals(
+      result.state.carCharger.lastCommandSent,
+      Some(CarChargerSignal.Off)
+    )
+    assertEquals(result.powerUsed, Power.zero)
+    assert(result.actions.nonEmpty)
+    assertEquals(result.actions.size, 2)
+
+    val mqttAction = result.actions.collectFirst {
+      case a: Action.SendMqttStringMessage => a
+    }.get
+    assertEquals(mqttAction.message, "off")
+  }
+
+}

--- a/src/test/scala/calespiga/processor/carCharger/CarChargerPowerProcessorSuite.scala
+++ b/src/test/scala/calespiga/processor/carCharger/CarChargerPowerProcessorSuite.scala
@@ -64,16 +64,16 @@ class CarChargerPowerProcessorSuite extends FunSuite {
   }
 
   test(
-    "CarChargerPowerCommandChanged SetAutomatic sends Off to microcontroller"
+    "CarChargerPowerCommandChanged SetAutomaticFV sends Off to microcontroller"
   ) {
     val initialState = stateWithCarCharger()
-    val event = CarChargerPowerCommandChanged(CarChargerSignal.SetAutomatic)
+    val event = CarChargerPowerCommandChanged(CarChargerSignal.SetAutomaticFV)
     val processor = CarChargerPowerProcessor(config)
     val (newState, actions) = processor.process(initialState, event, now)
 
     assertEquals(
       newState.carCharger.lastCommandReceived,
-      Some(CarChargerSignal.SetAutomatic)
+      Some(CarChargerSignal.SetAutomaticFV)
     )
     assertEquals(
       newState.carCharger.lastCommandSent,


### PR DESCRIPTION
This PR adds the dynamic consumer for the car charger, so in case of having selected the Automatic mode for the car charger, the Car charger may be activated if there is enough discarded FV power.

Note that in the naming the FV suffix is added for the automatic mode of the car charger. This is because in next PRs another automatic mode will be introduced, that uses the grid power. with this PR the naming wil not have to change.